### PR TITLE
Slightly tidy ubuntu1804 workflow

### DIFF
--- a/.github/workflows/Ubuntu1604.yml
+++ b/.github/workflows/Ubuntu1604.yml
@@ -19,10 +19,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Install CUDA
       run: |
-        sh ./scripts/install_cuda_ubuntu.sh
+        bash --version
+        ./scripts/install_cuda_ubuntu.sh
         if [[ $? -eq 0 ]]; then
           # Set paths for subsequent steps, using ${CUDA_PATH}
           echo "::set-env name=CUDA_PATH::${CUDA_PATH}"

--- a/.github/workflows/Ubuntu1604.yml
+++ b/.github/workflows/Ubuntu1604.yml
@@ -1,5 +1,5 @@
-name: Ubuntu1804
-# Ubuntu 18.04 with CUDA 9.0, 9.2, 10.0 and 10.2
+name: Ubuntu1604
+# Ubuntu 16.04 with CUDA 9.0, 9.2, 10.0 and 10.2
 
 on:
   push:

--- a/.github/workflows/Ubuntu1604.yml
+++ b/.github/workflows/Ubuntu1604.yml
@@ -1,5 +1,5 @@
+# Ubuntu 16.04 supports CUDA 8.0+
 name: Ubuntu1604
-# Ubuntu 16.04 with CUDA 9.0, 9.2, 10.0 and 10.2
 
 on:
   push:
@@ -9,47 +9,32 @@ on:
 
 jobs:
   build:
-    runs-on:  ${{ matrix.os }}
+    runs-on:  ubuntu-16.04
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04]
-        cuda: [9.0.176, 9.2.148, 10.0.130, 10.2.89]
+        cuda: [8.0, 9.0, 10.0]
     env:
       cuda: ${{ matrix.cuda }}
 
     steps:
     - uses: actions/checkout@v2
-
-    # Split version strings and set as environment variables for later use.
-    - name: split_version
+    
+    - name: Install CUDA
       run: |
-        echo "::set-env name=CUDA_MAJOR::$(echo "${{ env.cuda }}" | cut -d. -f1)"
-        echo "::set-env name=CUDA_MINOR::$(echo "${{ env.cuda }}" | cut -d. -f2)"
-        echo "::set-env name=CUDA_PATCH::$(echo "${{ env.cuda }}" | cut -d. -f3)"
-        echo "::set-env name=UBUNTU_VERSION::$(echo "${{ matrix.os }}" | tr -d '.\-')"
-
-    # @todo - would this be better in a script?
-    - name: Install cuda
-      run: |
-        sudo apt-get install apt-transport-https ca-certificates gnupg software-properties-common wget python3-pip doxygen
-        CUDA_REPO_PKG=cuda-repo-${UBUNTU_VERSION}_${CUDA_MAJOR}.${CUDA_MINOR}.${CUDA_PATCH}-1_amd64.deb
-        sudo wget https://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/7fa2af80.pub
-        sudo apt-key add 7fa2af80.pub
-        wget https://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/${CUDA_REPO_PKG}
-        sudo dpkg -i ${CUDA_REPO_PKG}
-        rm ${CUDA_REPO_PKG}
-        sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends cuda-compiler-${CUDA_MAJOR}-${CUDA_MINOR} cuda-cudart-dev-${CUDA_MAJOR}-${CUDA_MINOR} cuda-curand-dev-${CUDA_MAJOR}-${CUDA_MINOR} cuda-nvrtc-dev-${CUDA_MAJOR}-${CUDA_MINOR}
-        CUDA_ROOT=/usr/local/cuda-${CUDA_MAJOR}.${CUDA_MINOR}
-        echo "::set-env name=CUDA_ROOT::${CUDA_ROOT}"
-        echo "::set-env name=PATH::${CUDA_ROOT}/bin:${PATH}"
-        echo "::set-env name=LD_LIBRARY_PATH::${CUDA_ROOT}/lib:${LD_LIBRARY_PATH}"
+        sh ./scripts/install_cuda_ubuntu.sh
+        if [[ $? -eq 0 ]]; then
+          # Set paths for subsequent steps, using ${CUDA_PATH}
+          echo "::set-env name=CUDA_PATH::${CUDA_PATH}"
+          echo "::add-path::${CUDA_PATH}/bin"
+          echo "::set-env name=LD_LIBRARY_PATH::${CUDA_PATH}/lib:${LD_LIBRARY_PATH}"
+        fi
+      shell: bash
 
     - name: Install cpplint
       run: |
         pip3 install cpplint
-        echo "::set-env name=PATH::$HOME/.local/bin:${PATH}"
+        # echo "::set-env name=PATH::$HOME/.local/bin:${PATH}"
 
     - name: version_check
       run: |

--- a/.github/workflows/Ubuntu1604.yml
+++ b/.github/workflows/Ubuntu1604.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install cpplint
       run: |
         pip3 install cpplint
-        # echo "::set-env name=PATH::$HOME/.local/bin:${PATH}"
+        echo "::set-env name=PATH::$HOME/.local/bin:${PATH}"
 
     - name: version_check
       run: |

--- a/.github/workflows/Ubuntu1604.yml
+++ b/.github/workflows/Ubuntu1604.yml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cuda: ["8.0", "9.0", "10.0"]
+        cuda: ["8.0"]
+        # cuda: ["8.0", "9.0", "10.0"]
     env:
       cuda: ${{ matrix.cuda }}
 

--- a/.github/workflows/Ubuntu1604.yml
+++ b/.github/workflows/Ubuntu1604.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cuda: [8.0, 9.0, 10.0]
+        cuda: ["8.0", "9.0", "10.0"]
     env:
       cuda: ${{ matrix.cuda }}
 

--- a/.github/workflows/Ubuntu1604.yml
+++ b/.github/workflows/Ubuntu1604.yml
@@ -26,11 +26,15 @@ jobs:
         bash --version
         ./scripts/install_cuda_ubuntu.sh
         if [[ $? -eq 0 ]]; then
+          echo "Settings Paths"
+          echo "CUDA_PATH=${CUDA_PATH}"
           # Set paths for subsequent steps, using ${CUDA_PATH}
           echo "::set-env name=CUDA_PATH::${CUDA_PATH}"
           echo "::add-path::${CUDA_PATH}/bin"
           echo "::set-env name=LD_LIBRARY_PATH::${CUDA_PATH}/lib:${LD_LIBRARY_PATH}"
         fi
+        echo $PATH
+        nvcc -V
       shell: bash
 
     - name: Install cpplint

--- a/.github/workflows/Ubuntu1604.yml
+++ b/.github/workflows/Ubuntu1604.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-16.04]
         cuda: [9.0.176, 9.2.148, 10.0.130, 10.2.89]
     env:
       cuda: ${{ matrix.cuda }}

--- a/.github/workflows/Ubuntu1604.yml
+++ b/.github/workflows/Ubuntu1604.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install CUDA
       run: |
         bash --version
-        ./scripts/install_cuda_ubuntu.sh
+        source ./scripts/install_cuda_ubuntu.sh
         if [[ $? -eq 0 ]]; then
           echo "Settings Paths"
           echo "CUDA_PATH=${CUDA_PATH}"

--- a/.github/workflows/Ubuntu1804.yml
+++ b/.github/workflows/Ubuntu1804.yml
@@ -1,5 +1,5 @@
-# Ubuntu 16.04 supports CUDA 8.0+
-name: Ubuntu1604
+# Ubuntu 18.04 supports CUDA 10.0+
+name: Ubuntu1804
 
 on:
   push:
@@ -9,11 +9,11 @@ on:
 
 jobs:
   build:
-    runs-on:  ubuntu-16.04
+    runs-on:  ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
-        cuda: ["8.0", "9.0", "10.0"]
+        cuda: ["10.0", "10.1", "10.2"]
     env:
       cuda: ${{ matrix.cuda }}
 

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -1,8 +1,6 @@
-# This is a basic workflow to help you get started with Actions
+name: Ubuntu1804
+# Ubuntu 18.04 with CUDA 9.0, 9.2, 10.0 and 10.2
 
-name: build_ubuntu
-
-# Triggered on push/pr against master.
 on:
   push:
     branches: [ master ]
@@ -11,28 +9,28 @@ on:
 
 jobs:
   build:
-    # @todo -alternatively run on a docker container which already has dependencies installed.
     runs-on:  ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-18.04]
-        cuda: [10.1.105]
+        cuda: [9.0.176, 9.2.148, 10.0.130, 10.2.89]
+      env:
+        cuda: ${{ matrix.cuda }}
 
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
     # Split version strings and set as environment variables for later use.
     - name: split_version
       run: |
-        echo "::set-env name=CUDA_MAJOR::$(echo "${{ matrix.cuda }}" | cut -d. -f1)"
-        echo "::set-env name=CUDA_MINOR::$(echo "${{ matrix.cuda }}" | cut -d. -f2)"
-        echo "::set-env name=CUDA_PATCH::$(echo "${{ matrix.cuda }}" | cut -d. -f3)"
+        echo "::set-env name=CUDA_MAJOR::$(echo "${{ env.cuda }}" | cut -d. -f1)"
+        echo "::set-env name=CUDA_MINOR::$(echo "${{ env.cuda }}" | cut -d. -f2)"
+        echo "::set-env name=CUDA_PATCH::$(echo "${{ env.cuda }}" | cut -d. -f3)"
         echo "::set-env name=UBUNTU_VERSION::$(echo "${{ matrix.os }}" | tr -d '.\-')"
 
-    # Investigate apt caching? https://stackoverflow.com/questions/59269850/caching-apt-packages-in-github-actions-workflow
     # @todo - would this be better in a script?
-    - name: install cuda
+    - name: Install cuda
       run: |
         sudo apt-get install apt-transport-https ca-certificates gnupg software-properties-common wget python3-pip doxygen
         CUDA_REPO_PKG=cuda-repo-${UBUNTU_VERSION}_${CUDA_MAJOR}.${CUDA_MINOR}.${CUDA_PATCH}-1_amd64.deb
@@ -48,7 +46,7 @@ jobs:
         echo "::set-env name=PATH::${CUDA_ROOT}/bin:${PATH}"
         echo "::set-env name=LD_LIBRARY_PATH::${CUDA_ROOT}/lib:${LD_LIBRARY_PATH}"
 
-    - name: install cpplint
+    - name: Install cpplint
       run: |
         pip3 install cpplint
         echo "::set-env name=PATH::$HOME/.local/bin:${PATH}"
@@ -63,19 +61,19 @@ jobs:
         cmake --version
         which cmake
 
-    - name: configure
+    - name: Configure cmake
       run: |
         mkdir -p build
         cd build
-        cmake ..
-    - name: compile
-      run: |
-        cd build
-        make
-    # Disabled - cannot execute on github-hosted actions.
-    # - name: execute
-    #   run: |
-    #     cd build
-    #     ./main
+        cmake .. -DCMAKE_BUILD_TYPE=Release
+
+    - name: Build
+      run: cmake --build . --target all --verbose -j 2
+      working-directory: build
+
+# No GPU so no point in running
+    - name: Run
+      run: ./main
+      working-directory: build
 
 

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         os: [ubuntu-18.04]
         cuda: [9.0.176, 9.2.148, 10.0.130, 10.2.89]
-      env:
-        cuda: ${{ matrix.cuda }}
+    env:
+      cuda: ${{ matrix.cuda }}
 
     steps:
     - uses: actions/checkout@v2

--- a/scripts/install_cuda_ubuntu.sh
+++ b/scripts/install_cuda_ubuntu.sh
@@ -9,7 +9,7 @@
 
 # List of packages to install.
 CUDA_PACKAGES_IN=(
-    "compiler"
+    "command-line-tools"
     "curand-dev"
     "nvrtc-dev"
 )
@@ -88,6 +88,7 @@ fi
 CUDA_PACKAGES=""
 for package in "${CUDA_PACKAGES_IN[@]}"
 do : 
+    # @todo This is not perfect. Should probably provide a separate list for diff versions
     # cuda-compiler-X-Y if CUDA >= 9.1 else cuda-nvcc-X-Y
     if [[ "${package}" == "nvcc" ]] && version_ge "$CUDA_VERSION_MAJOR_MINOR" "9.1" ; then
         package="compiler"
@@ -115,11 +116,14 @@ echo "APT_KEY_URL ${APT_KEY_URL}"
 ## -----------------
 ## Install
 ## -----------------
+echo "Adding CUDA Repository"
 wget ${PIN_URL}
 sudo mv ${PIN_FILENAME} /etc/apt/preferences.d/cuda-repository-pin-600
 sudo apt-key adv --fetch-keys ${APT_KEY_URL}
 sudo add-apt-repository "deb ${REPO_URL} /"
 sudo apt-get update
+
+echo "Installing CUDA packages ${CUDA_PACKAGES}"
 sudo apt-get -y install ${CUDA_PACKAGES}
 
 if [[ $? -ne 0 ]]; then
@@ -138,4 +142,4 @@ export CUDA_PATH=${CUDA_PATH}
 # Quick test. @temp
 export PATH="$CUDA_PATH/bin:$PATH"
 export LD_LIBRARY_PATH="$CUDA_PATH/lib:$LD_LIBRARY_PATH"
-nvcc -v
+nvcc -V

--- a/scripts/install_cuda_ubuntu.sh
+++ b/scripts/install_cuda_ubuntu.sh
@@ -1,0 +1,138 @@
+# @todo - better / more robust parsing of inputs from env vars.
+## -------------------
+## Constants
+## -------------------
+
+# @todo - apt repos/known supported versions?
+
+# @todo - GCC support matrix?
+
+# List of packages to install.
+CUDA_PACKAGES_IN=(
+    "compiler"
+    "curand-dev"
+    "nvrtc-dev"
+)
+
+## -------------------
+## Bash functions
+## -------------------
+# returns 0 (true) if a >= b
+function version_ge() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$2" ]
+}
+# returns 0 (true) if a > b
+function version_gt() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$1" = "$2" ] && return 1 || version_ge $1 $2
+}
+# returns 0 (true) if a <= b
+function version_le() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$1" ]
+}
+# returns 0 (true) if a < b
+function version_lt() {
+    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [ "$1" = "$2" ] && return 1 || version_le $1 $2
+}
+
+## -------------------
+## Select CUDA version
+## -------------------
+
+# Get the cuda version from the environment as $cuda.
+CUDA_VERSION_MAJOR_MINOR=${cuda}
+
+# Split the version.
+# We (might/probably) don't know PATCH at this point - it depends which version gets installed.
+CUDA_MAJOR=$(echo "${CUDA_VERSION_MAJOR_MINOR}" | cut -d. -f1)
+CUDA_MINOR=$(echo "${CUDA_VERSION_MAJOR_MINOR}" | cut -d. -f2)
+CUDA_PATCH=$(echo "${CUDA_VERSION_MAJOR_MINOR}" | cut -d. -f3)
+# use lsb_release to find the OS.
+UBUNTU_VERSION=$(lsb_release -sr)
+UBUNTU_VERSION="${UBUNTU_VERSION//.}"
+
+echo "CUDA_MAJOR: ${CUDA_MAJOR}"
+echo "CUDA_MINOR: ${CUDA_MINOR}"
+echo "CUDA_PATCH: ${CUDA_PATCH}"
+# echo "UBUNTU_NAME: ${UBUNTU_NAME}"
+echo "UBUNTU_VERSION: ${UBUNTU_VERSION}"
+
+# If we don't know the CUDA_MAJOR or MINOR, error.
+if [ -z "${CUDA_MAJOR}" ] ; then
+    echo "Error: Unknown CUDA Major version. Aborting."
+    exit 1
+fi
+if [ -z "${CUDA_MINOR}" ] ; then
+    echo "Error: Unknown CUDA Minor version. Aborting."
+    exit 1
+fi
+# If we don't know the Ubuntu version, error.
+if [ -z ${UBUNTU_VERSION} ]; then
+    echo "Error: Unknown Ubuntu version. Aborting."
+    exit 1
+fi
+
+
+## ---------------------------
+## GCC studio support check?
+## ---------------------------
+
+# @todo
+
+## -------------------------------
+## Select CUDA packages to install
+## -------------------------------
+CUDA_PACKAGES=""
+for package in "${CUDA_PACKAGES_IN[@]}"
+do : 
+    # cuda-compiler-X-Y if CUDA >= 9.1 else cuda-nvcc-X-Y
+    if [[ "${package}" == "nvcc" ]] && version_ge "$CUDA_VERSION_MAJOR_MINOR" "9.1" ; then
+        package="compiler"
+    elif [[ "${package}" == "compiler" ]] && version_lt "$CUDA_VERSION_MAJOR_MINOR" "9.1" ; then
+        package="nvcc"
+    fi
+    # Build the full package name and append to the string.
+    CUDA_PACKAGES+=" cuda-${package}-${CUDA_MAJOR}-${CUDA_MINOR}"
+done
+echo "CUDA_PACKAGES ${CUDA_PACKAGES}"
+
+## -----------------
+## Prepare to install
+## -----------------
+
+PIN_FILENAME="cuda-ubuntu${UBUNTU_VERSION}.pin"
+PIN_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/${PIN_FILENAME}"
+APT_KEY_URL="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/7fa2af80.pub"
+REPO_URL="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/"
+
+echo "PIN_FILENAME ${PIN_FILENAME}"
+echo "PIN_URL ${PIN_URL}"
+echo "APT_KEY_URL ${APT_KEY_URL}"
+
+## -----------------
+## Install
+## -----------------
+
+wget ${PIN_URL}
+sudo mv ${PIN_FILENAME} /etc/apt/preferences.d/cuda-repository-pin-600
+sudo apt-key adv --fetch-keys ${APT_KEY_URL}
+sudo add-apt-repository "deb ${REPO_URL} /"
+sudo apt-get update
+sudo apt-get -y install ${CUDA_PACKAGES}
+
+## -----------------
+## Set environment vars / vars to be propagated
+## -----------------
+
+CUDA_PATH=/usr/local/cuda-${CUDA_MAJOR}.${CUDA_MINOR}
+echo "CUDA_PATH=${CUDA_PATH}"
+export CUDA_PATH=${CUDA_PATH}
+
+
+# Quick test. @temp
+export PATH="$CUDA_PATH/bin:$PATH"
+export LD_LIBRARY_PATH="$CUDA_PATH/lib:$LD_LIBRARY_PATH"
+nvcc -v

--- a/scripts/install_cuda_ubuntu.sh
+++ b/scripts/install_cuda_ubuntu.sh
@@ -115,7 +115,6 @@ echo "APT_KEY_URL ${APT_KEY_URL}"
 ## -----------------
 ## Install
 ## -----------------
-
 wget ${PIN_URL}
 sudo mv ${PIN_FILENAME} /etc/apt/preferences.d/cuda-repository-pin-600
 sudo apt-key adv --fetch-keys ${APT_KEY_URL}
@@ -123,6 +122,10 @@ sudo add-apt-repository "deb ${REPO_URL} /"
 sudo apt-get update
 sudo apt-get -y install ${CUDA_PACKAGES}
 
+if [[ $? -ne 0 ]]; then
+    echo "CUDA Installation Error."
+    exit 1
+fi
 ## -----------------
 ## Set environment vars / vars to be propagated
 ## -----------------


### PR DESCRIPTION
Should move CUDA installation into a script to make it cleaner / match Windows.

ideally:
+ `ubuntu_install_cuda.sh`
    + [x] Provide it with the CUDA version via env var (or argument to the script?)
    + [x] Nicely structures subpackage processing
    + [x] Sets an environment variable which is then propagated as scripts don't seem to do it properly?
    + [x] Remove split_version step, folding into the script
    + [ ] Validate CUDA version is supported before install? 1604 = CUDA 8+?, 1804=CUDA10+?, 2004 will be 11.?+
    + [x] Correct subpackage name for nvcc / cuda_compiler (CUDA 9.x)