### PR TITLE
Removed deprecated env manipulations

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -74,9 +74,9 @@ jobs:
         if [[ $? -eq 0 ]]; then
           # Set paths for subsequent steps, using ${CUDA_PATH}
           echo "Adding CUDA to CUDA_PATH, PATH and LD_LIBRARY_PATH"
-          echo "::set-env name=CUDA_PATH::${CUDA_PATH}"
-          echo "::add-path::${CUDA_PATH}/bin"
-          echo "::set-env name=LD_LIBRARY_PATH::${CUDA_PATH}/lib:${LD_LIBRARY_PATH}"
+          echo "CUDA_PATH=${CUDA_PATH}" >> $GITHUB_ENV
+          echo "${CUDA_PATH}/bin" >> $GITHUB_PATH
+          echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
         fi
       shell: bash
 
@@ -84,9 +84,9 @@ jobs:
     - name: Install/Select gcc and g++ 
       run: |
         sudo apt-get install -y gcc-${{ matrix.gcc }} g++-${{ matrix.gcc }}
-        echo "::set-env name=CC::/usr/bin/gcc-${{ matrix.gcc }}"
-        echo "::set-env name=CXX::/usr/bin/g++-${{ matrix.gcc }}"
-        echo "::set-env name=CUDAHOSTCXX::/usr/bin/g++-${{ matrix.gcc }}"
+        echo "CC=/usr/bin/gcc-${{ matrix.gcc }}" >> $GITHUB_ENV
+        echo "CXX=/usr/bin/g++-${{ matrix.gcc }}" >> $GITHUB_ENV
+        echo "CUDAHOSTCXX=/usr/bin/g++-${{ matrix.gcc }}" >> $GITHUB_ENV
 
     - name: Configure cmake
       id: configure

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -64,9 +64,9 @@ jobs:
         if ($?) {
           # Set paths for subsequent steps, using $env:CUDA_PATH
           echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
-          echo "::set-env name=CUDA_PATH::$env:CUDA_PATH"
-          echo "::set-env name=$env:CUDA_PATH_VX_Y::$env:CUDA_PATH"
-          echo "::add-path::$env:CUDA_PATH/bin"
+          echo "CUDA_PATH=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "$env:CUDA_PATH_VX_Y=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "$env:CUDA_PATH/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         }
 
     - name: nvcc check


### PR DESCRIPTION
`add-path` and `set-env` [are deprecated and will be removed soon](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w). This PR replaces them with the [new syntax](https://github.com/actions/toolkit/blob/main/docs/commands.md#environment-files)