### PR TITLE
https URIs 

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -39,33 +39,9 @@ jobs:
             cuda: "10.1"
             gcc: 8
 
-          # 16.04 supports CUDA 8+
-          # - os: ubuntu-16.04
-          #   cuda: "11.0"
-          #   gcc: 7
-          # - os: ubuntu-16.04
-          #   cuda: "10.2"
-          #   gcc: 7
-          # - os: ubuntu-16.04
-          #   cuda: "10.1"
-          #   gcc: 7
-          # - os: ubuntu-16.04
-          #   cuda: "10.0"
-          #   gcc: 7
-          # - os: ubuntu-16.04
-          #   cuda: "9.2"
-          #   gcc: 7
-          # - os: ubuntu-16.04
-          #   cuda: "9.1"
-          #   gcc: 6
-          - os: ubuntu-16.04
-            cuda: "9.0"
-            gcc: 6
-
-          # Libraries-dev subpackage does not exist for CUDA 8. Should make a better way of providing version specific subpackages.
-          # - os: ubuntu-16.04
-          #   cuda: "8.0"
-          #   gcc: 6
+          # 16.04 runners are deprecated / removed in september 2021.
+          # It should still be possible to install CUDA 8 - CUDA 10 in 18.04 images by using the 16.04 repository, although milage may vary.
+          # @todo - modify script so this can be passed via a bash variable as an override / incase lsb_release is unavailable 
     env:
       build_dir: "build"
       config: "Release"

--- a/scripts/actions/install_cuda_ubuntu.sh
+++ b/scripts/actions/install_cuda_ubuntu.sh
@@ -109,8 +109,8 @@ echo "CUDA_PACKAGES ${CUDA_PACKAGES}"
 
 PIN_FILENAME="cuda-ubuntu${UBUNTU_VERSION}.pin"
 PIN_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/${PIN_FILENAME}"
-APT_KEY_URL="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/7fa2af80.pub"
-REPO_URL="http://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/"
+APT_KEY_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/7fa2af80.pub"
+REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/"
 
 echo "PIN_FILENAME ${PIN_FILENAME}"
 echo "PIN_URL ${PIN_URL}"


### PR DESCRIPTION
Use `https` rather than `http` for URIs. 

This appears to now be required for Ubuntu 20.04, either due to an apt change or due to an nvidia server configuration change.

Also adds checking for root/sudo avialability, for use inside containers.

Unclear if this will break oldee ubuntu's until CI has ran. 

removes Ubuntu 16.04 workflow runs, as they are deprecated and will be removed on 2021-09-20