### PR TITLE
Gha annotations

### DIFF
--- a/.github/problem-matchers.json
+++ b/.github/problem-matchers.json
@@ -1,0 +1,56 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "cpplint",
+            "severity": "error",
+            "pattern": [
+                {
+                "regexp": "^(.+):(\\d+):\\s+(.+)\\[(.+)\\]\\s+\\[(.+)\\]$",
+                "file": 1,
+                "line": 2,
+                "message": 3,
+                "code": 4
+                }
+            ]
+        },
+        {
+            "owner": "gcc",
+            "pattern": [
+                {
+                    "regexp": "^(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        },
+        {
+            "owner": "msbuild",
+            "pattern": [
+                {
+                    "regexp": "^(?:\\s+\\d+\\>)?([^\\s].*)\\((\\d+),?(\\d+)?(?:,\\d+,\\d+)?\\)\\s*:\\s+(error|warning|info)\\s+(\\w{1,2}\\d+)\\s*:\\s*(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "code": 5,
+                    "message": 6
+                }
+            ]
+        },
+        {
+            "owner": "nvcc",
+            "pattern": [
+                {
+                    "regexp": "^(.*)\\((\\d+)\\):\\s+(warning|error)\\s*:\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "severity": 3,
+                    "message": 4
+                }
+            ]
+        }
+    ]
+}

--- a/.github/problem-matchers.json
+++ b/.github/problem-matchers.json
@@ -44,7 +44,7 @@
             "owner": "nvcc",
             "pattern": [
                 {
-                    "regexp": "^(.*)\\((\\d+)\\):\\s+(warning|error)\\s*:\\s+(.*)$",
+                    "regexp": "^(?:\\s+\\d+\\>)?([^\\s].*)\\((\\d+)\\):\\s+(warning|error)\\s*:\\s+(.*)$",
                     "file": 1,
                     "line": 2,
                     "severity": 3,

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "**"
       - "!.github/**"
+      - ".github/problem-matchers.json"
       - ".github/workflows/Ubuntu.yml"
   # pull_request:
   #   paths:
@@ -54,6 +55,9 @@ jobs:
         cuda: ${{ matrix.cuda }}
       run: ./scripts/actions/install_cuda_ubuntu.sh
       shell: bash
+
+    - name: Add custom problem matchers for annotations
+      run: echo "::add-matcher::.github/problem-matchers.json"
 
     # Specify the correct host compilers
     - name: Install/Select gcc and g++ 

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "**"
       - "!.github/**"
+      - ".github/problem-matchers.json"
       - ".github/workflows/Windows.yml"
   # pull_request:
   #   paths:
@@ -68,6 +69,9 @@ jobs:
         visual_studio: ${{ matrix.visual_studio }}
       shell: powershell
       run: .\scripts\actions\install_cuda_windows.ps1
+
+    - name: Add custom problem matchers for annotations
+      run: echo "::add-matcher::.github/problem-matchers.json"
 
     - name: nvcc check
       shell: powershell

--- a/include/test.cuh
+++ b/include/test.cuh
@@ -5,8 +5,10 @@
 // example function from a header.
 
 __global__ void helloWorldDevice(){
+    double x = 0;
     if(threadIdx.x + blockIdx.x * blockDim.x < 1){
         printf("Hello World from the device\n");
+        atomicAdd(&x, 1);
     }
 }
 


### PR DESCRIPTION
Enable github annotations via a custom problem matcher, with support for msvc, gcc and nvcc errors/warnigns + cpplint parsing. 

Do not merge without reverting / dropping the commit which introduces a sample error.