### PR TITLE
Ci cuda keyfix

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -41,19 +41,6 @@ jobs:
           #   cuda: "10.1.243"
           #   visual_studio: "Visual Studio 16 2019"
 
-          # Windows2016 & VS 2017 supports 10.0+
-          # - os: windows-2016
-          #   cuda: "11.0.167"
-          #   visual_studio: "Visual Studio 15 2017"
-          # - os: windows-2016
-          #   cuda: "10.2.89"
-          #   visual_studio: "Visual Studio 15 2017"
-          # - os: windows-2016
-          #   cuda: "10.1.243"
-          #   visual_studio: "Visual Studio 15 2017"
-          - os: windows-2016
-            cuda: "10.0.130"
-            visual_studio: "Visual Studio 15 2017"
 
     env:
       build_dir: "build"

--- a/scripts/actions/install_cuda_ubuntu.sh
+++ b/scripts/actions/install_cuda_ubuntu.sh
@@ -116,14 +116,17 @@ echo "CUDA_PACKAGES ${CUDA_PACKAGES}"
 ## -----------------
 ## Prepare to install
 ## -----------------
-
+CPU_ARCH="x86_64"
 PIN_FILENAME="cuda-ubuntu${UBUNTU_VERSION}.pin"
-PIN_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/${PIN_FILENAME}"
-APT_KEY_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/7fa2af80.pub"
-REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/"
+PIN_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/${CPU_ARCH}/${PIN_FILENAME}"
+# apt keyring package now available https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/
+KERYRING_PACKAGE_FILENAME="cuda-keyring_1.0-1_all.deb"
+KEYRING_PACKAGE_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/${CPU_ARCH}/${KERYRING_PACKAGE_FILENAME}"
+REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/${CPU_ARCH}/"
 
 echo "PIN_FILENAME ${PIN_FILENAME}"
 echo "PIN_URL ${PIN_URL}"
+echo "KEYRING_PACKAGE_URL ${KEYRING_PACKAGE_URL}"
 echo "APT_KEY_URL ${APT_KEY_URL}"
 
 ## -----------------
@@ -156,7 +159,7 @@ fi
 echo "Adding CUDA Repository"
 wget ${PIN_URL}
 $USE_SUDO mv ${PIN_FILENAME} /etc/apt/preferences.d/cuda-repository-pin-600
-$USE_SUDO apt-key adv --fetch-keys ${APT_KEY_URL}
+wget ${KEYRING_PACKAGE_URL} && ${USE_SUDO} dpkg -i ${KERYRING_PACKAGE_FILENAME} && rm ${KERYRING_PACKAGE_FILENAME}
 $USE_SUDO add-apt-repository "deb ${REPO_URL} /"
 $USE_SUDO apt-get update
 

--- a/scripts/actions/install_cuda_ubuntu.sh
+++ b/scripts/actions/install_cuda_ubuntu.sh
@@ -3,18 +3,18 @@
 ## Constants
 ## -------------------
 
-# @todo - apt repos/known supported versions?
-
-# @todo - GCC support matrix?
-
 # List of sub-packages to install.
 # @todo - pass this in from outside the script? 
 # @todo - check the specified subpackages exist via apt pre-install?  apt-rdepends cuda-9-0 | grep "^cuda-"?
 
-# Ideally choose from the list of meta-packages to minimise variance between cuda versions (although it does change too)
+# Ideally choose from the list of meta-packages to minimise variance between cuda versions (although it does change too). Some of these packages may not be availble pre cuda 10.
 CUDA_PACKAGES_IN=(
-    "command-line-tools"
-    "libraries-dev"
+    "cuda-compiler"
+    "cuda-cudart-dev"
+    "cuda-nvtx"
+    "cuda-nvrtc-dev"
+    "libcurand-dev" # 11-0+
+    "cuda-cccl" # 11.4+, provides cub and thrust. On 11.3 knwon as cuda-thrust-11-3
 )
 
 ## -------------------
@@ -79,12 +79,6 @@ if [ -z ${UBUNTU_VERSION} ]; then
 fi
 
 
-## ---------------------------
-## GCC studio support check?
-## ---------------------------
-
-# @todo
-
 ## -------------------------------
 ## Select CUDA packages to install
 ## -------------------------------
@@ -93,13 +87,29 @@ for package in "${CUDA_PACKAGES_IN[@]}"
 do : 
     # @todo This is not perfect. Should probably provide a separate list for diff versions
     # cuda-compiler-X-Y if CUDA >= 9.1 else cuda-nvcc-X-Y
-    if [[ "${package}" == "nvcc" ]] && version_ge "$CUDA_VERSION_MAJOR_MINOR" "9.1" ; then
-        package="compiler"
-    elif [[ "${package}" == "compiler" ]] && version_lt "$CUDA_VERSION_MAJOR_MINOR" "9.1" ; then
-        package="nvcc"
+    if [[ "${package}" == "cuda-nvcc" ]] && version_ge "$CUDA_VERSION_MAJOR_MINOR" "9.1" ; then
+        package="cuda-compiler"
+    elif [[ "${package}" == "cuda-compiler" ]] && version_lt "$CUDA_VERSION_MAJOR_MINOR" "9.1" ; then
+        package="cuda-nvcc"
+    # CUB/Thrust  are packages in cuda-thrust in 11.3, but cuda-cccl in 11.4+
+    elif [[ "${package}" == "cuda-thrust" || "${package}" == "cuda-cccl" ]]; then
+        # CUDA cuda-thrust >= 11.4
+        if version_ge "$CUDA_VERSION_MAJOR_MINOR" "11.4" ; then
+            package="cuda-cccl"
+        # Use cuda-thrust > 11.2
+        elif version_ge "$CUDA_VERSION_MAJOR_MINOR" "11.3" ; then
+            package="cuda-thrust"
+        # Do not include this pacakge < 11.3
+        else
+            continue
+        fi
+    fi
+    # CUDA 11+ includes lib* / lib*-dev packages, which if they existed previously where cuda-cu*- / cuda-cu*-dev-
+    if [[ ${package} == libcu* ]] && version_lt "$CUDA_VERSION_MAJOR_MINOR" "11.0" ; then
+        package="${package/libcu/cuda-cu}"
     fi
     # Build the full package name and append to the string.
-    CUDA_PACKAGES+=" cuda-${package}-${CUDA_MAJOR}-${CUDA_MINOR}"
+    CUDA_PACKAGES+=" ${package}-${CUDA_MAJOR}-${CUDA_MINOR}"
 done
 echo "CUDA_PACKAGES ${CUDA_PACKAGES}"
 
@@ -130,8 +140,8 @@ has_sudo=false
 if command -v sudo &> /dev/null ; then
     has_sudo=true
 fi
-# Decide if we can proceed or not (root or sudo is required) and if so store whether sudo should be used or not.
-if [ "$is_root" = false ] && [ "$has_sudo" = false ]; then
+# Decide if we can proceed or not (root or sudo is required) and if so store whether sudo should be used or not. 
+if [ "$is_root" = false ] && [ "$has_sudo" = false ]; then 
     echo "Root or sudo is required. Aborting."
     exit 1
 elif [ "$is_root" = false ] ; then
@@ -157,6 +167,7 @@ if [[ $? -ne 0 ]]; then
     echo "CUDA Installation Error."
     exit 1
 fi
+
 ## -----------------
 ## Set environment vars / vars to be propagated
 ## -----------------
@@ -164,12 +175,12 @@ fi
 CUDA_PATH=/usr/local/cuda-${CUDA_MAJOR}.${CUDA_MINOR}
 echo "CUDA_PATH=${CUDA_PATH}"
 export CUDA_PATH=${CUDA_PATH}
-
-
-# Quick test. @temp
 export PATH="$CUDA_PATH/bin:$PATH"
 export LD_LIBRARY_PATH="$CUDA_PATH/lib:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="$CUDA_PATH/lib64:$LD_LIBRARY_PATH"
+# Check nvcc is now available.
 nvcc -V
+
 
 # If executed on github actions, make the appropriate echo statements to update the environment
 if [[ $GITHUB_ACTIONS ]]; then
@@ -178,4 +189,5 @@ if [[ $GITHUB_ACTIONS ]]; then
     echo "CUDA_PATH=${CUDA_PATH}" >> $GITHUB_ENV
     echo "${CUDA_PATH}/bin" >> $GITHUB_PATH
     echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+    echo "LD_LIBRARY_PATH=${CUDA_PATH}/lib64:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 fi


### PR DESCRIPTION
CUDA debian repo keys have been changed. See https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/

Also improves expands cuda subpackage logic which varies in more recent cuda versions