### PR TITLE
CUDA 12.0

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -47,7 +47,7 @@ jobs:
       config: "Release"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install CUDA
       env:

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -1,18 +1,14 @@
 # Compile project on Ubuntu
 name: Ubuntu
-
 on:
   push:
     paths:
       - "**"
       - "!.github/**"
       - ".github/workflows/Ubuntu.yml"
-  # pull_request:
-  #   paths:
-  #     - "**"
-  #     - "!.github"
-  #     - ".github/workflows/Ubuntu.yml"
-
+      - "!scripts/"
+      - "scripts/actions/install_cuda_ubuntu.sh"
+      - "!*.md"
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -17,27 +17,44 @@ jobs:
       # explicit include-based build matrix, of known valid options
       matrix:
         include:
+          # 22.04 supports CUDA 11.7+
+          - os: ubuntu-22.04
+            cuda: "12.0"
+            gcc: 11
+          - os: ubuntu-22.04
+            cuda: "11.8"
+            gcc: 10
+          - os: ubuntu-22.04
+            cuda: "11.7"
+            gcc: 10
           # 20.04 supports CUDA 11.0+
+          - os: ubuntu-20.04
+            cuda: "11.6"
+            gcc: 10
+          - os: ubuntu-20.04
+            cuda: "11.5"
+            gcc: 10
+          - os: ubuntu-20.04
+            cuda: "11.4"
+            gcc: 10
           - os: ubuntu-20.04
             cuda: "11.3"
             gcc: 10
-          # - os: ubuntu-20.04
-          #   cuda: "11.2"
-          #   gcc: 10
-          # 18.04 supports CUDA 10.1+ (gxx <= 8)
-          # - os: ubuntu-18.04
-          #   cuda: "11.0"
-          #   gcc: 8
+          - os: ubuntu-20.04
+            cuda: "11.2"
+            gcc: 10
+          - os: ubuntu-20.04
+            cuda: "11.0"
+            gcc: 9
+          # 18.04 supports CUDA 10.1+ (gxx <= 8), but were deprecated on 2022-08-08 and unsupported from 2023-04-01
           # - os: ubuntu-18.04
           #   cuda: "10.2"
           #   gcc: 8
-          - os: ubuntu-18.04
-            cuda: "10.1"
-            gcc: 8
-
+          # - os: ubuntu-18.04
+          #   cuda: "10.1"
+          #   gcc: 8
           # 16.04 runners are deprecated / removed in september 2021.
-          # It should still be possible to install CUDA 8 - CUDA 10 in 18.04 images by using the 16.04 repository, although milage may vary.
-          # @todo - modify script so this can be passed via a bash variable as an override / incase lsb_release is unavailable 
+          # It should still be possible to install CUDA 8 - CUDA 10 in 18.04 images by using the 16.04 repository, but install_cuda_ubuntu.sh would require changes to do so / a way to override the repository to use.
     env:
       build_dir: "build"
       config: "Release"
@@ -65,17 +82,19 @@ jobs:
 
     - name: Configure Error Processing
       if: ${{ failure() && steps.configure.outcome == 'failure' }}
-      working-directory: ${{ env.build_dir }}
       run: |
-          if [[ -f "CMakeFiles/CMakeOutput.log" ]]; then
-            echo "---- CMakeFiles/CMakeOutput.log"
-            cat CMakeFiles/CMakeOutput.log
-            echo "----"
-          fi
-          if [[ -f "CMakeFiles/CMakeError.log" ]]; then
-            echo "---- CMakeFiles/CMakeError.log"
-            cat CMakeFiles/CMakeError.log
-            echo "----"
+          if [[ -d "${{ env.build_dir }}" ]]; then
+            pushd "${{ env.build_dir }}"
+            if [[ -f "CMakeFiles/CMakeOutput.log" ]]; then
+              echo "---- CMakeFiles/CMakeOutput.log"
+              cat CMakeFiles/CMakeOutput.log
+              echo "----"
+            fi
+            if [[ -f "CMakeFiles/CMakeError.log" ]]; then
+              echo "---- CMakeFiles/CMakeError.log"
+              cat CMakeFiles/CMakeError.log
+              echo "----"
+            fi
           fi
 
 

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -17,26 +17,44 @@ jobs:
       # explicit include-based build matrix, of known valid options
       matrix:
         include:
-          # Windows2019 & VS 2019 supports 10.1+
+          # Windows-2022 & VS 2022 supports 11.6+
+          - os: windows-2022
+            cuda: "12.0.0"
+            visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "11.8.0"
+            visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "11.7.0"
+            visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "11.6.0"
+            visual_studio: "Visual Studio 17 2022"
+          # Windows-2019 & VS 2019 supports 10.1+
+          - os: windows-2019
+            cuda: "11.5.0"
+            visual_studio: "Visual Studio 16 2019"
+          - os: windows-2019
+            cuda: "11.4.0"
+            visual_studio: "Visual Studio 16 2019"
           - os: windows-2019
             cuda: "11.3.0"
             visual_studio: "Visual Studio 16 2019"
-          # - os: windows-2019
-          #   cuda: "11.2.2"
-          #   visual_studio: "Visual Studio 16 2019"
-          # - os: windows-2019
-          #   cuda: "11.1.1"
-          #   visual_studio: "Visual Studio 16 2019"
-          # - os: windows-2019
-          #   cuda: "11.0.3"
-          #   visual_studio: "Visual Studio 16 2019"
-          # - os: windows-2019
-          #   cuda: "10.2.89"
-          #   visual_studio: "Visual Studio 16 2019"
-          # - os: windows-2019
-          #   cuda: "10.1.243"
-          #   visual_studio: "Visual Studio 16 2019"
-
+          - os: windows-2019
+            cuda: "11.2.0"
+            visual_studio: "Visual Studio 16 2019"
+          - os: windows-2019
+            cuda: "11.1.0"
+            visual_studio: "Visual Studio 16 2019"
+          - os: windows-2019
+            cuda: "11.0.1"
+            visual_studio: "Visual Studio 16 2019"
+          - os: windows-2019
+            cuda: "10.2.89"
+            visual_studio: "Visual Studio 16 2019"
+          - os: windows-2019
+            cuda: "10.1.243"
+            visual_studio: "Visual Studio 16 2019"
 
     env:
       build_dir: "build"
@@ -71,18 +89,20 @@ jobs:
 
     - name: Configure Error Processing
       if: ${{ (failure() && steps.configure.outcome == 'failure') || success() }}
-      working-directory: ${{ env.build_dir }}
       shell: bash
       run: |
-          if [[ -f "CMakeFiles/CMakeOutput.log" ]]; then
-            echo "---- CMakeFiles/CMakeOutput.log"
-            cat CMakeFiles/CMakeOutput.log
-            echo "----"
-          fi
-          if [[ -f "CMakeFiles/CMakeError.log" ]]; then
-            echo "---- CMakeFiles/CMakeError.log"
-            cat CMakeFiles/CMakeError.log
-            echo "----"
+          if [[ -d "${{ env.build_dir }}" ]]; then
+            pushd "${{ env.build_dir }}"
+            if [[ -f "CMakeFiles/CMakeOutput.log" ]]; then
+              echo "---- CMakeFiles/CMakeOutput.log"
+              cat CMakeFiles/CMakeOutput.log
+              echo "----"
+            fi
+            if [[ -f "CMakeFiles/CMakeError.log" ]]; then
+              echo "---- CMakeFiles/CMakeError.log"
+              cat CMakeFiles/CMakeError.log
+              echo "----"
+            fi
           fi
 
     - name: Build

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -47,7 +47,7 @@ jobs:
       config: "Release"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install CUDA
       env: 

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,18 +1,14 @@
 # Windows builds.
 name: Windows
-
 on:
   push:
     paths:
       - "**"
       - "!.github/**"
       - ".github/workflows/Windows.yml"
-  # pull_request:
-  #   paths:
-  #     - "**"
-  #     - "!.github"
-  #     - ".github/workflows/Windows.yml"
-
+      - "!scripts"
+      - "scripts/install_cuda_windows.ps1"
+      - "!*.md"
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/readme.md
+++ b/readme.md
@@ -1,52 +1,61 @@
 # CUDA + Cmake example using Github Actions
 
-This repo is a very simple CUDA application, used to GitHub Actions as a CI service for CUDA compilation.
+This repo contains CI installation scripts, workflow examples and a very simple CUDA application, to demonstrate the installation of the CUDA toolkit (but not driver) on GitHub Hosted runners.
+Execution of CUDA code is not (yet) possible on GitHub hosted runners.
 
-This will **potentially** be expanded to investigate self-hosted runner(s) for running tests locally.
+Network CUDA installers are used, with a hard-coded set of subpackages to install within each installation script, to avoid large and slow installation processes.
 
 [![Ubuntu](https://github.com/ptheywood/cuda-cmake-github-actions/workflows/Ubuntu/badge.svg)](https://github.com/ptheywood/cuda-cmake-github-actions/actions?query=workflow%3AUbuntu)
 [![Windows](https://github.com/ptheywood/cuda-cmake-github-actions/workflows/Windows/badge.svg)](https://github.com/ptheywood/cuda-cmake-github-actions/actions?query=workflow%3AWindows)
 
+## CUDA and GitHub Actions Version Compatibility
+
+CUDA is only supported with appropriate host compilers and host operating systems.
+
+This support matrix can be found in the CUDA documentation, but to summarise (at the time of writing): 
+
+
+| Runner | Host Compiler | CUDA |
+|--------|------|---------------|
+| [ubuntu-2204] | GCC 12 | >= `12.0` |
+| [ubuntu-2204] | GCC 6 - 11 | >= `11.7` |
+| [ubuntu-2004] | GCC 10 | >= `11.4`  (`11.4.1`) |
+| [ubuntu-2004] | GCC 6 - 9 | >= `11.0` |
+| [windows-2022] | Visual Studio 17 2022 | >= `11.6.0`  |
+| [windows-2019] | Visual Studio 16 2019 | >= `10.1.243` |
+
+Deprecated/Removed Runners previously supported:
+
+| Runner | Host Compiler | CUDA |
+|--------|------|---------------|
+| [ubuntu-1804] | GCC 10 | >= `11.4`  (`11.4.1`) |
+| [ubuntu-1804] | GCC 6 - 9 | >= `10.0` |
+
+[ubuntu-2204]: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
+[ubuntu-2004]: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md
+[ubuntu-1804]: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu1804-Readme.md
+[windows-2022]: https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md
+[windows-2019]: https://github.com/actions/runner-images/blob/master/images/win/Windows2019-Readme.md
+
 ## Sample application
 
-To be representative of a real world example this should include:
+To ensure the installed compilers are usable, a very simple CUDA C++ test application is included, requiring CMake >= 3.10 for native CUDA support. 3.18+ has much improved CUDA support.
 
-+ `cmake` for cross platform build tooling
-+ `nvcc` to compile .cu code.
-+ some form of test script?
+It simply prints `hello world` from the host and from a single thread on the device.
 
-## Compilation
+This does not specify any cuda architectures to target, using the nvcc defaults. From CMake 3.18, use `CMAKE_CUDA_ARCHITECTURES`.
+
+### Compilation
 
 ```bash
-mkdir -p build
-cd build
+mkdir -p build && cd build
 cmake .. 
-make
+cmake --build .
 ```
 
-## Execution
+### Execution
 
 ```bash
 cd build
 ./main
 ```
-
-## Version Compatibility
-
-CUDA is only supported with appropriate host compilers.
-
-This support matrix can be found in the CUDA documentation, however, there are some obvious caveats related to the current state of github actions (at the time of writing)
-
-+ [Windows-2019](https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md#visual-studio-2019-enterprise)
-    + Visual Studio `16.5.5` which maps to [`_MSC_VER 1925`](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019)
-        + `CUDA >= 10.1`
-            + `CUDA 10.0` requires `_MSC_VER` between `1700` and `1920`
-+ [Ubuntu 18.04](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md#ubuntu-18044-lts)
-    + GNU C++ `7.5.0`, `8.4.0` & `9.3.0` are available
-    + CUDA `10.0+` are available in the apt repository.
-        + You can use the older `1604` apt repo to enable `CUDA 8.0+`
-+ [Ubuntu 20.04](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu2004-README.md#ubuntu-20044-lts)
-    + GNU C++  `9.4.0`, `10.3.0` are available#
-        + GNU C++ `10.3.0` leads to errors when using `<chrono>` with NVCC in `--std=C++17` mode. This has been addressed in GCC, but the patch hasn't made it to Ubuntu packaged GCC.
-    + CUDA `11.0+` are available in the apt repository.
-        + You can use the older `1804` apt repo to enable `CUDA 10.0+`, but this is an unsupported configuration which may lead to errors.

--- a/scripts/actions/install_cuda_ubuntu.sh
+++ b/scripts/actions/install_cuda_ubuntu.sh
@@ -127,7 +127,6 @@ REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNT
 echo "PIN_FILENAME ${PIN_FILENAME}"
 echo "PIN_URL ${PIN_URL}"
 echo "KEYRING_PACKAGE_URL ${KEYRING_PACKAGE_URL}"
-echo "APT_KEY_URL ${APT_KEY_URL}"
 
 ## -----------------
 ## Check for root/sudo

--- a/scripts/actions/install_cuda_ubuntu.sh
+++ b/scripts/actions/install_cuda_ubuntu.sh
@@ -7,14 +7,14 @@
 # @todo - pass this in from outside the script? 
 # @todo - check the specified subpackages exist via apt pre-install?  apt-rdepends cuda-9-0 | grep "^cuda-"?
 
-# Ideally choose from the list of meta-packages to minimise variance between cuda versions (although it does change too). Some of these packages may not be availble pre cuda 10.
+# Ideally choose from the list of meta-packages to minimise variance between cuda versions (although it does change too). Some of these packages may not be availble in older CUDA releases
 CUDA_PACKAGES_IN=(
     "cuda-compiler"
     "cuda-cudart-dev"
     "cuda-nvtx"
     "cuda-nvrtc-dev"
     "libcurand-dev" # 11-0+
-    "cuda-cccl" # 11.4+, provides cub and thrust. On 11.3 knwon as cuda-thrust-11-3
+    "cuda-cccl" # 11.4+, provides cub and thrust. On 11.3 known as cuda-thrust-11-3
 )
 
 ## -------------------
@@ -183,7 +183,6 @@ export LD_LIBRARY_PATH="$CUDA_PATH/lib:$LD_LIBRARY_PATH"
 export LD_LIBRARY_PATH="$CUDA_PATH/lib64:$LD_LIBRARY_PATH"
 # Check nvcc is now available.
 nvcc -V
-
 
 # If executed on github actions, make the appropriate echo statements to update the environment
 if [[ $GITHUB_ACTIONS ]]; then

--- a/scripts/actions/install_cuda_windows.ps1
+++ b/scripts/actions/install_cuda_windows.ps1
@@ -2,18 +2,20 @@
 ## Constants
 ## -------------------
 
-# Dictionary of known cuda versions and thier download URLS, which do not follow a consistent pattern :(
+# Dictionary of known cuda versions and thier download URLS, which do not follow a consistent pattern
+# From 11.0, the download url/toolkit version is separate from the cudart version.
+# Releases since 11.5.1 (including 11.4.4) use `windows` rather than `win10` in the uri, due to windows 11 inclusion
 $CUDA_KNOWN_URLS = @{
-    "8.0.44" = "https://developer.nvidia.com/compute/cuda/8.0/Prod/network_installers/cuda_8.0.44_win10_network-exe";
-    "8.0.61" = "https://developer.nvidia.com/compute/cuda/8.0/Prod2/network_installers/cuda_8.0.61_win10_network-exe";
-    "9.0.176" = "https://developer.nvidia.com/compute/cuda/9.0/Prod/network_installers/cuda_9.0.176_win10_network-exe";
-    "9.1.85" = "https://developer.nvidia.com/compute/cuda/9.1/Prod/network_installers/cuda_9.1.85_win10_network";
-    "9.2.148" = "https://developer.nvidia.com/compute/cuda/9.2/Prod2/network_installers2/cuda_9.2.148_win10_network";
+    "8.0.44"   = "https://developer.nvidia.com/compute/cuda/8.0/Prod/network_installers/cuda_8.0.44_win10_network-exe";
+    "8.0.61"   = "https://developer.nvidia.com/compute/cuda/8.0/Prod2/network_installers/cuda_8.0.61_win10_network-exe";
+    "9.0.176"  = "https://developer.nvidia.com/compute/cuda/9.0/Prod/network_installers/cuda_9.0.176_win10_network-exe";
+    "9.1.85"   = "https://developer.nvidia.com/compute/cuda/9.1/Prod/network_installers/cuda_9.1.85_win10_network";
+    "9.2.148"  = "https://developer.nvidia.com/compute/cuda/9.2/Prod2/network_installers2/cuda_9.2.148_win10_network";
     "10.0.130" = "https://developer.nvidia.com/compute/cuda/10.0/Prod/network_installers/cuda_10.0.130_win10_network";
     "10.1.105" = "https://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.105_win10_network.exe";
     "10.1.168" = "https://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.168_win10_network.exe";
     "10.1.243" = "https://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
-    "10.2.89" = "https://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
+    "10.2.89"  = "https://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
     "11.0.1" = "https://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe";
     "11.0.2" = "https://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe";
     "11.0.3" = "https://developer.download.nvidia.com/compute/cuda/11.0.3/network_installers/cuda_11.0.3_win10_network.exe";
@@ -23,14 +25,30 @@ $CUDA_KNOWN_URLS = @{
     "11.2.1" = "https://developer.download.nvidia.com/compute/cuda/11.2.1/network_installers/cuda_11.2.1_win10_network.exe";
     "11.2.2" = "https://developer.download.nvidia.com/compute/cuda/11.2.2/network_installers/cuda_11.2.2_win10_network.exe";
     "11.3.0" = "https://developer.download.nvidia.com/compute/cuda/11.3.0/network_installers/cuda_11.3.0_win10_network.exe";
-    "11.4.0" = "https://developer.download.nvidia.com/compute/cuda/11.4.0/network_installers/cuda_11.4.0_win10_network.exe"
+    "11.3.1" = "https://developer.download.nvidia.com/compute/cuda/11.3.1/network_installers/cuda_11.3.1_win10_network.exe";
+    "11.4.0" = "https://developer.download.nvidia.com/compute/cuda/11.4.0/network_installers/cuda_11.4.0_win10_network.exe";
+    "11.4.1" = "https://developer.download.nvidia.com/compute/cuda/11.4.1/network_installers/cuda_11.4.1_win10_network.exe";
+    "11.4.2" = "https://developer.download.nvidia.com/compute/cuda/11.4.2/network_installers/cuda_11.4.2_win10_network.exe";
+    "11.4.3" = "https://developer.download.nvidia.com/compute/cuda/11.4.3/network_installers/cuda_11.4.3_win10_network.exe";
+    "11.4.4" = "https://developer.download.nvidia.com/compute/cuda/11.4.4/network_installers/cuda_11.4.4_windows_network.exe";
+    "11.5.0" = "https://developer.download.nvidia.com/compute/cuda/11.5.0/network_installers/cuda_11.5.0_win10_network.exe";
+    "11.5.1" = "https://developer.download.nvidia.com/compute/cuda/11.5.1/network_installers/cuda_11.5.1_windows_network.exe";
+    "11.5.2" = "https://developer.download.nvidia.com/compute/cuda/11.5.2/network_installers/cuda_11.5.2_windows_network.exe";
+    "11.6.0" = "https://developer.download.nvidia.com/compute/cuda/11.6.0/network_installers/cuda_11.6.0_windows_network.exe";
+    "11.6.1" = "https://developer.download.nvidia.com/compute/cuda/11.6.1/network_installers/cuda_11.6.1_windows_network.exe";
+    "11.6.2" = "https://developer.download.nvidia.com/compute/cuda/11.6.2/network_installers/cuda_11.6.2_windows_network.exe";
+    "11.7.0" = "https://developer.download.nvidia.com/compute/cuda/11.7.0/network_installers/cuda_11.7.0_windows_network.exe";
+    "11.7.1" = "https://developer.download.nvidia.com/compute/cuda/11.7.1/network_installers/cuda_11.7.1_windows_network.exe";
+    "11.8.0" = "https://developer.download.nvidia.com/compute/cuda/11.8.0/network_installers/cuda_11.8.0_windows_network.exe";
+    "12.0.0" = "https://developer.download.nvidia.com/compute/cuda/12.0.0/network_installers/cuda_12.0.0_windows_network.exe"
 }
 
-# @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead?
+# @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead
 $VISUAL_STUDIO_MIN_CUDA = @{
+    "2022" = "11.6.0";
     "2019" = "10.1";
-    "2017" = "10.0"; # Depends on which version of 2017! 9.0 to 10.0 depending on  version
-    "2015" = "8.0"; # might support older, unsure.
+    "2017" = "10.0"; # Depends on which version of 2017! 9.0 to 10.0 depending on version
+    "2015" = "8.0";  # Might support older, unsure. Depracated as of 11.1, unsupported in 11.2
 }
 
 # cuda_runtime.h is in nvcc <= 10.2, but cudart >= 11.0
@@ -41,8 +59,8 @@ $CUDA_PACKAGES_IN = @(
     "curand_dev";
     "nvrtc_dev";
     "cudart";
+    "thrust";
 )
-
 
 ## -------------------
 ## Select CUDA version
@@ -85,23 +103,17 @@ $VISUAL_STUDIO_YEAR = $VISUAL_STUDIO.Substring($VISUAL_STUDIO.Length-4)
 ## ------------------------------------------------
 
 $CUDA_PACKAGES = ""
-
-# for CUDA >= 11 cudart is a required package.
-# if([version]$CUDA_VERSION_FULL -ge [version]"11.0") {
-#     if(-not $CUDA_PACKAGES_IN -contains "cudart") {
-#         $CUDA_PACKAGES_IN += 'cudart'
-#     }
-# }
-
 Foreach ($package in $CUDA_PACKAGES_IN) {
     # Make sure the correct package name is used for nvcc.
     if($package -eq "nvcc" -and [version]$CUDA_VERSION_FULL -lt [version]"9.1"){
         $package="compiler"
     } elseif($package -eq "compiler" -and [version]$CUDA_VERSION_FULL -ge [version]"9.1") {
         $package="nvcc"
+    } elseif($package -eq "thrust" -and [version]$CUDA_VERSION_FULL -lt [version]"11.3") {
+        # Thrust is a package from CUDA 11.3, otherwise it should be skipped.
+        continue
     }
     $CUDA_PACKAGES += " $($package)_$($CUDA_MAJOR).$($CUDA_MINOR)"
-
 }
 echo "$($CUDA_PACKAGES)"
 ## -----------------
@@ -110,28 +122,55 @@ echo "$($CUDA_PACKAGES)"
 
 # Select the download link if known, otherwise have a guess.
 $CUDA_REPO_PKG_REMOTE=""
+$CUDA_REPO_PKG_LOCAL=""
 if($CUDA_KNOWN_URLS.containsKey($CUDA_VERSION_FULL)){
     $CUDA_REPO_PKG_REMOTE=$CUDA_KNOWN_URLS[$CUDA_VERSION_FULL]
 } else{
     # Guess what the url is given the most recent pattern (at the time of writing, 10.1)
     Write-Output "note: URL for CUDA ${$CUDA_VERSION_FULL} not known, estimating."
-    $CUDA_REPO_PKG_REMOTE="http://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
+    if([version]$CUDA_VERSION_FULL -ge [version]"11.5.1"){
+        $CUDA_REPO_PKG_REMOTE="https://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_windows_network.exe"
+    } else {
+        $CUDA_REPO_PKG_REMOTE="https://developer.download.nvidia.com/compute/cuda/$($CUDA_MAJOR).$($CUDA_MINOR)/Prod/network_installers/cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
+    }
 }
-$CUDA_REPO_PKG_LOCAL="cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
-
+if([version]$CUDA_VERSION_FULL -ge [version]"11.5.1"){
+    $CUDA_REPO_PKG_LOCAL="cuda_$($CUDA_VERSION_FULL)_windows_network.exe"
+} else {
+    $CUDA_REPO_PKG_LOCAL="cuda_$($CUDA_VERSION_FULL)_win10_network.exe"
+}
 
 ## ------------
 ## Install CUDA
 ## ------------
 
-# Get CUDA network installer
+# Get CUDA network installer, retrying upto N times.
 Write-Output "Downloading CUDA Network Installer for $($CUDA_VERSION_FULL) from: $($CUDA_REPO_PKG_REMOTE)"
-Invoke-WebRequest $CUDA_REPO_PKG_REMOTE -OutFile $CUDA_REPO_PKG_LOCAL | Out-Null
-if(Test-Path -Path $CUDA_REPO_PKG_LOCAL){
-    Write-Output "Downloading Complete"
-} else {
-    Write-Output "Error: Failed to download $($CUDA_REPO_PKG_LOCAL) from $($CUDA_REPO_PKG_REMOTE)"
-    exit 1
+
+$downloaded = $false
+$download_attempt = 0
+$download_attempt_delay = 30
+$download_attempts_max = 5
+
+while (-not $downloaded) {
+    Invoke-WebRequest $CUDA_REPO_PKG_REMOTE -OutFile $CUDA_REPO_PKG_LOCAL | Out-Null
+    $download_attempt++
+    # If download succeeded, break out the loop.
+    if(Test-Path -Path $CUDA_REPO_PKG_LOCAL){
+        Write-Output "Downloading Complete"
+        $downloaded=$true
+    } else {
+        # If downlaod failed, either wait and try again, or give up and error.
+        if ($download_attempt -le $download_attempts_max) {
+            Write-Output "Error: Failed to download $($CUDA_REPO_PKG_LOCAL) (attempt $($download_attempt)/$($download_attempts_max)). Retrying."
+            # Sleep for a number of seconds.
+            Start-Sleep $download_attempt_delay
+        } else {
+            Write-Output "Error: Failed to download $($CUDA_REPO_PKG_LOCAL) after $($download_attempts_max) attempts. Aborting."
+            # Abort the script.
+            exit 1
+        }
+    }
 }
 
 # Invoke silent install of CUDA (via network installer)
@@ -141,12 +180,12 @@ Start-Process -Wait -FilePath .\"$($CUDA_REPO_PKG_LOCAL)" -ArgumentList "-s $($C
 # Check the return status of the CUDA installer.
 if (!$?) {
     Write-Output "Error: CUDA installer reported error. $($LASTEXITCODE)"
-    exit 1 
+    exit 1
 }
 
 # Store the CUDA_PATH in the environment for the current session, to be forwarded in the action.
 $CUDA_PATH = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$($CUDA_MAJOR).$($CUDA_MINOR)"
-$CUDA_PATH_VX_Y = "CUDA_PATH_V$($CUDA_MAJOR)_$($CUDA_MINOR)" 
+$CUDA_PATH_VX_Y = "CUDA_PATH_V$($CUDA_MAJOR)_$($CUDA_MINOR)"
 # Set environmental variables in this session
 $env:CUDA_PATH = "$($CUDA_PATH)"
 $env:CUDA_PATH_VX_Y = "$($CUDA_PATH_VX_Y)"
@@ -157,9 +196,8 @@ Write-Output "CUDA_PATH_VX_Y $($CUDA_PATH_VX_Y)"
 # Append $CUDA_PATH/bin to path.
 # Set CUDA_PATH as an environmental variable
 
-
 # If executing on github actions, emit the appropriate echo statements to update environment variables
-if (Test-Path "env:GITHUB_ACTIONS") { 
+if (Test-Path "env:GITHUB_ACTIONS") {
     # Set paths for subsequent steps, using $env:CUDA_PATH
     echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
     echo "CUDA_PATH=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append


### PR DESCRIPTION
Update for versions upto CUDA 12.0

+ [x] Update deprecated github actions
+ Update `install_cuda_windows.ps1`
  + [x] Add all known versions upto 12.0
  + [x] Add thrust subpackage knowledge
  + [x] Update predicted download names due to win10/windows change since 11.5.1 (+11.4.4)
+ Update `install_cuda_ubuntu`
  + [x] install thrust in 11.3+ via the appropraite subpackage
+ [x] Restrict CI triggers to relevant files only.
+ [x] Broaden the build matrix
+ [x] Update readme