### PR TITLE
Windows via Redist

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -17,44 +17,9 @@ jobs:
       # explicit include-based build matrix, of known valid options
       matrix:
         include:
-          # 22.04 supports CUDA 11.7+
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             cuda: "12.0"
             gcc: 11
-          - os: ubuntu-22.04
-            cuda: "11.8"
-            gcc: 10
-          - os: ubuntu-22.04
-            cuda: "11.7"
-            gcc: 10
-          # 20.04 supports CUDA 11.0+
-          - os: ubuntu-20.04
-            cuda: "11.6"
-            gcc: 10
-          - os: ubuntu-20.04
-            cuda: "11.5"
-            gcc: 10
-          - os: ubuntu-20.04
-            cuda: "11.4"
-            gcc: 10
-          - os: ubuntu-20.04
-            cuda: "11.3"
-            gcc: 10
-          - os: ubuntu-20.04
-            cuda: "11.2"
-            gcc: 10
-          - os: ubuntu-20.04
-            cuda: "11.0"
-            gcc: 9
-          # 18.04 supports CUDA 10.1+ (gxx <= 8), but were deprecated on 2022-08-08 and unsupported from 2023-04-01
-          # - os: ubuntu-18.04
-          #   cuda: "10.2"
-          #   gcc: 8
-          # - os: ubuntu-18.04
-          #   cuda: "10.1"
-          #   gcc: 8
-          # 16.04 runners are deprecated / removed in september 2021.
-          # It should still be possible to install CUDA 8 - CUDA 10 in 18.04 images by using the 16.04 repository, but install_cuda_ubuntu.sh would require changes to do so / a way to override the repository to use.
     env:
       build_dir: "build"
       config: "Release"

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-            cuda: "12.0"
+            cuda: "13.0"
             gcc: 11
     env:
       build_dir: "build"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -107,14 +107,6 @@ jobs:
         ls $env:CUDA_PATH\bin
         ls $env:CUDA_PATH\include
 
-    - name: Enable Developer Command Prompt
-      uses: ilammy/msvc-dev-cmd@v1.13.0
-
-    - name: manual nvcc
-      shell: bash
-      run: |
-        nvcc -o main src/main.cu -Iinclude -Imain -std=c++14
-
     - name: cmake version
       shell: bash
       run: cmake --version

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -96,7 +96,7 @@ jobs:
 
         # Move files from each extracted zip directory into the actual location
         cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_nvcc-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\visual_studio_integration-windows-x86_64-13.0*. -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 85-archive\"
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\visual_studio_integration-windows-x86_64-13.0.85-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
         cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libcurand-windows-x86_64-10.4.0.35-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
         cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_nvrtc-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
         cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_cudart-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -16,28 +16,29 @@ jobs:
       fail-fast: false
       # explicit include-based build matrix, of known valid options
       matrix:
+        redist:
+          - "true"
+          - "false"
         include:
           # Windows-2022 & VS 2022 supports 12.4 without any workarounds
           - os: windows-2022
             cuda: "13.0.1"
-            redist: "true"
-            visual_studio: "Visual Studio 17 2022"
-          - os: windows-2022
-            cuda: "13.0.1"
-            redist: "false"
             visual_studio: "Visual Studio 17 2022"
           - os: windows-2022
             cuda: "12.9.1"
-            redist: "true"
             visual_studio: "Visual Studio 17 2022"
           - os: windows-2022
-            cuda: "12.9.1"
-            redist: "false"
+            cuda: "12.8.0"
             visual_studio: "Visual Studio 17 2022"
-          # - os: windows-2022
-          #   cuda: "12.4.0"
-          #   redist: "false"
-          #   visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "12.6.3"
+            visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "12.5.1"
+            visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "12.4.0"
+            visual_studio: "Visual Studio 17 2022"
     env:
       build_dir: "build"
       config: "Release"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -53,6 +53,19 @@ jobs:
       shell: pwsh
       run: | 
         vswhere.exe -latest -products * -property installationPath
+        
+        $vs_install_dir = vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+        if ($vs_install_dir) {
+          $vc_tools_version_path = join-path $vs_install_dir 'VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt'
+          if (test-path $vc_tools_version_path) {
+            $version = gc -raw $vc_tools_version_path
+            if ($version) {
+              $version = $version.Trim()
+              $path = join-path $vs_install_dir "VC\Tools\MSVC\$version\bin\Hostx64\x64\cl.exe"
+              echo "$path"
+            }
+          }
+        }
 
       # Note: redist doesnt' include dev headers of everything so this might not work...
     - name: Install CUDA (redist)
@@ -64,6 +77,7 @@ jobs:
       run: |
         # find the visual studio build-customisation directorie(s)
         # $vs_path = & "vswhere.exe" -latest -products * -property installationPath
+        
 
         # Todo: download the manifest json and then do subpacakge matching
 

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -95,16 +95,16 @@ jobs:
         rm "libnvvm-windows-x86_64-13.0.88-archive.zip"
 
         # Move files from each extracted zip directory into the actual location
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_nvcc-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\visual_studio_integration-windows-x86_64-13.0.85-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libcurand-windows-x86_64-10.4.0.35-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_nvrtc-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_cudart-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_cccl-windows-x86_64-13.0.85-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libnvjitlink-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_crt-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libnvptxcompiler-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libnvvm-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_nvcc-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\visual_studio_integration-windows-x86_64-13.0.85-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"-Recurse -Force
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libcurand-windows-x86_64-10.4.0.35-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_nvrtc-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_cudart-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_cccl-windows-x86_64-13.0.85-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libnvjitlink-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_crt-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libnvptxcompiler-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libnvvm-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
 
         # Export env vars (pwsh required?)
         "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\bin" >> $env:GITHUB_PATH

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -74,6 +74,11 @@ jobs:
             cuda: "12.0.0"
             redist: "false"
             visual_studio: "Visual Studio 17 2022"
+          # Check redist 11.x behaves, by not being redist
+          - os: windows-2022
+            cuda: "11.6.1"
+            redist: "true"
+            visual_studio: "Visual Studio 17 2022"
     env:
       build_dir: "build"
       config: "Release"
@@ -97,7 +102,12 @@ jobs:
         cuda: ${{ matrix.cuda }}
         visual_studio: ${{ matrix.visual_studio }}
       shell: pwsh
-      run: .\scripts\actions\install_cuda_windows_redist.ps1
+      run: |
+        if ([version]$env:cuda -ge [version]"12.0") {
+          .\scripts\actions\install_cuda_windows_redist.ps1
+        } else {
+          .\scripts\actions\install_cuda_windows.ps1
+        }
 
     - name: nvcc check
       shell: powershell

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -16,28 +16,55 @@ jobs:
       fail-fast: false
       # explicit include-based build matrix, of known valid options
       matrix:
-        redist:
-          - "true"
-          - "false"
         include:
           # Windows-2022 & VS 2022 supports 12.4 without any workarounds
           - os: windows-2022
             cuda: "13.0.1"
+            redist: "true"
+            visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "13.0.1"
+            redist: "false"
             visual_studio: "Visual Studio 17 2022"
           - os: windows-2022
             cuda: "12.9.1"
+            redist: "true"
+            visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "12.9.1"
+            redist: "false"
             visual_studio: "Visual Studio 17 2022"
           - os: windows-2022
             cuda: "12.8.0"
+            redist: "true"
+            visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "12.8.0"
+            redist: "false"
             visual_studio: "Visual Studio 17 2022"
           - os: windows-2022
             cuda: "12.6.3"
+            redist: "true"
+            visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "12.6.3"
+            redist: "false"
             visual_studio: "Visual Studio 17 2022"
           - os: windows-2022
             cuda: "12.5.1"
+            redist: "true"
+            visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "12.5.1"
+            redist: "false"
             visual_studio: "Visual Studio 17 2022"
           - os: windows-2022
             cuda: "12.4.0"
+            redist: "true"
+            visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "12.4.0"
+            redist: "false"
             visual_studio: "Visual Studio 17 2022"
     env:
       build_dir: "build"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -26,10 +26,14 @@ jobs:
             cuda: "13.0.1"
             redist: "false"
             visual_studio: "Visual Studio 17 2022"
-          # - os: windows-2022
-          #   cuda: "12.9.0"
-          #   redist: "false"
-          #   visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "12.9.1"
+            redist: "true"
+            visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "12.9.1"
+            redist: "false"
+            visual_studio: "Visual Studio 17 2022"
           # - os: windows-2022
           #   cuda: "12.4.0"
           #   redist: "false"
@@ -49,93 +53,13 @@ jobs:
       shell: powershell
       run: .\scripts\actions\install_cuda_windows.ps1
 
-    - name: vshwere test
-      shell: pwsh
-      run: | 
-        vswhere.exe -latest -products * -property installationPath
-        
-        $vs_install_dir = vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
-        if ($vs_install_dir) {
-          $vc_tools_version_path = join-path $vs_install_dir 'VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt'
-          if (test-path $vc_tools_version_path) {
-            $version = gc -raw $vc_tools_version_path
-            if ($version) {
-              $version = $version.Trim()
-              $path = join-path $vs_install_dir "VC\Tools\MSVC\$version\bin\Hostx64\x64\cl.exe"
-              echo "$path"
-            }
-          }
-        }
-
-      # Note: redist doesnt' include dev headers of everything so this might not work...
     - name: Install CUDA (redist)
       if: ${{ matrix.redist == 'true' }}
       env: 
         cuda: ${{ matrix.cuda }}
         visual_studio: ${{ matrix.visual_studio }}
       shell: pwsh
-      run: |
-        # find the visual studio build-customisation directorie(s)
-        # $vs_path = & "vswhere.exe" -latest -products * -property installationPath
-        
-
-        # Todo: download the manifest json and then do subpacakge matching
-
-        # Download cuda redist zips for relevant subpackages
-        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/windows-x86_64/cuda_nvcc-windows-x86_64-13.0.88-archive.zip"
-        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/visual_studio_integration/windows-x86_64/visual_studio_integration-windows-x86_64-13.0.85-archive.zip"
-        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/libcurand/windows-x86_64/libcurand-windows-x86_64-10.4.0.35-archive.zip"
-        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvrtc/windows-x86_64/cuda_nvrtc-windows-x86_64-13.0.88-archive.zip"
-        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_cudart/windows-x86_64/cuda_cudart-windows-x86_64-13.0.88-archive.zip"
-        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_cccl/windows-x86_64/cuda_cccl-windows-x86_64-13.0.85-archive.zip"
-        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/libnvjitlink/windows-x86_64/libnvjitlink-windows-x86_64-13.0.88-archive.zip"
-        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_crt/windows-x86_64/cuda_crt-windows-x86_64-13.0.88-archive.zip"
-        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/libnvptxcompiler/windows-x86_64/libnvptxcompiler-windows-x86_64-13.0.88-archive.zip"
-        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/libnvvm/windows-x86_64/libnvvm-windows-x86_64-13.0.88-archive.zip"
-        # make the cuda toolkit dir
-        mkdir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0"
-
-        # unzip all the zip files into the toolkit dir
-        7z.exe x "cuda_nvcc-windows-x86_64-13.0.88-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
-        7z.exe x "visual_studio_integration-windows-x86_64-13.0.85-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
-        7z.exe x "libcurand-windows-x86_64-10.4.0.35-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
-        7z.exe x "cuda_nvrtc-windows-x86_64-13.0.88-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
-        7z.exe x "cuda_cudart-windows-x86_64-13.0.88-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
-        7z.exe x "cuda_cccl-windows-x86_64-13.0.85-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
-        7z.exe x "libnvjitlink-windows-x86_64-13.0.88-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
-        7z.exe x "cuda_crt-windows-x86_64-13.0.88-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
-        7z.exe x "libnvptxcompiler-windows-x86_64-13.0.88-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
-        7z.exe x "libnvvm-windows-x86_64-13.0.88-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
-
-        # delete the zip files
-        rm "cuda_nvcc-windows-x86_64-13.0.88-archive.zip"
-        rm "visual_studio_integration-windows-x86_64-13.0.85-archive.zip"
-        rm "libcurand-windows-x86_64-10.4.0.35-archive.zip"
-        rm "cuda_nvrtc-windows-x86_64-13.0.88-archive.zip"
-        rm "cuda_cudart-windows-x86_64-13.0.88-archive.zip"
-        rm "cuda_cccl-windows-x86_64-13.0.85-archive.zip"
-        rm "libnvjitlink-windows-x86_64-13.0.88-archive.zip"
-        rm "cuda_crt-windows-x86_64-13.0.88-archive.zip"
-        rm "libnvptxcompiler-windows-x86_64-13.0.88-archive.zip"
-        rm "libnvvm-windows-x86_64-13.0.88-archive.zip"
-
-        # Move files from each extracted zip directory into the actual location
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_nvcc-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\visual_studio_integration-windows-x86_64-13.0.85-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"-Recurse -Force
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libcurand-windows-x86_64-10.4.0.35-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_nvrtc-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_cudart-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_cccl-windows-x86_64-13.0.85-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libnvjitlink-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_crt-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libnvptxcompiler-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
-        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libnvvm-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" -Recurse -Force
-
-        # Export env vars (pwsh required?)
-        "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\bin" >> $env:GITHUB_PATH
-        "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\nvvm" >> $env:GITHUB_PATH
-        "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0" >> $env:GITHUB_ENV
-        "CUDA_PATH_V13_0=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0" >> $env:GITHUB_ENV
+      run: .\scripts\actions\install_cuda_windows_redist.ps1
 
     - name: nvcc check
       shell: powershell

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -66,9 +66,19 @@ jobs:
             cuda: "12.4.0"
             redist: "false"
             visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "11.6.1"
+            redist: "true"
+            visual_studio: "Visual Studio 17 2022"
+          - os: windows-2022
+            cuda: "11.6.1"
+            redist: "false"
+            visual_studio: "Visual Studio 17 2022"
     env:
       build_dir: "build"
       config: "Release"
+      # Ensure MSVC >= 1940 works with CUDA <= 12.3
+      NVCC_PREPEND_FLAGS: "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH --allow-unsupported-compiler"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -17,45 +17,16 @@ jobs:
       # explicit include-based build matrix, of known valid options
       matrix:
         include:
-          # Windows-2022 & VS 2022 supports 11.6+
+          # Windows-2022 & VS 2022 supports 12.4 without any workarounds
           - os: windows-2022
-            cuda: "12.0.0"
+            cuda: "13.0.1"
             visual_studio: "Visual Studio 17 2022"
           - os: windows-2022
-            cuda: "11.8.0"
+            cuda: "12.9.0"
             visual_studio: "Visual Studio 17 2022"
           - os: windows-2022
-            cuda: "11.7.0"
+            cuda: "12.4.0"
             visual_studio: "Visual Studio 17 2022"
-          - os: windows-2022
-            cuda: "11.6.0"
-            visual_studio: "Visual Studio 17 2022"
-          # Windows-2019 & VS 2019 supports 10.1+
-          - os: windows-2019
-            cuda: "11.5.0"
-            visual_studio: "Visual Studio 16 2019"
-          - os: windows-2019
-            cuda: "11.4.0"
-            visual_studio: "Visual Studio 16 2019"
-          - os: windows-2019
-            cuda: "11.3.0"
-            visual_studio: "Visual Studio 16 2019"
-          - os: windows-2019
-            cuda: "11.2.0"
-            visual_studio: "Visual Studio 16 2019"
-          - os: windows-2019
-            cuda: "11.1.0"
-            visual_studio: "Visual Studio 16 2019"
-          - os: windows-2019
-            cuda: "11.0.1"
-            visual_studio: "Visual Studio 16 2019"
-          - os: windows-2019
-            cuda: "10.2.89"
-            visual_studio: "Visual Studio 16 2019"
-          - os: windows-2019
-            cuda: "10.1.243"
-            visual_studio: "Visual Studio 16 2019"
-
     env:
       build_dir: "build"
       config: "Release"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -49,6 +49,11 @@ jobs:
       shell: powershell
       run: .\scripts\actions\install_cuda_windows.ps1
 
+    - name: vshwere test
+      shell: pwsh
+      run: | 
+        vswhere.exe -latest -products * -property installationPath
+
       # Note: redist doesnt' include dev headers of everything so this might not work...
     - name: Install CUDA (redist)
       if: ${{ matrix.redist == 'true' }}
@@ -57,6 +62,12 @@ jobs:
         visual_studio: ${{ matrix.visual_studio }}
       shell: pwsh
       run: |
+        # find the visual studio build-customisation directorie(s)
+        # $vs_path = & "vswhere.exe" -latest -products * -property installationPath
+
+        # Todo: download the manifest json and then do subpacakge matching
+
+        # Download cuda redist zips for relevant subpackages
         curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/windows-x86_64/cuda_nvcc-windows-x86_64-13.0.88-archive.zip"
         curl -O "https://developer.download.nvidia.com/compute/cuda/redist/visual_studio_integration/windows-x86_64/visual_studio_integration-windows-x86_64-13.0.85-archive.zip"
         curl -O "https://developer.download.nvidia.com/compute/cuda/redist/libcurand/windows-x86_64/libcurand-windows-x86_64-10.4.0.35-archive.zip"

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -20,13 +20,20 @@ jobs:
           # Windows-2022 & VS 2022 supports 12.4 without any workarounds
           - os: windows-2022
             cuda: "13.0.1"
+            redist: "true"
             visual_studio: "Visual Studio 17 2022"
           - os: windows-2022
-            cuda: "12.9.0"
+            cuda: "13.0.1"
+            redist: "false"
             visual_studio: "Visual Studio 17 2022"
-          - os: windows-2022
-            cuda: "12.4.0"
-            visual_studio: "Visual Studio 17 2022"
+          # - os: windows-2022
+          #   cuda: "12.9.0"
+          #   redist: "false"
+          #   visual_studio: "Visual Studio 17 2022"
+          # - os: windows-2022
+          #   cuda: "12.4.0"
+          #   redist: "false"
+          #   visual_studio: "Visual Studio 17 2022"
     env:
       build_dir: "build"
       config: "Release"
@@ -35,11 +42,74 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install CUDA
+      if: ${{ matrix.redist == 'false' }}
       env: 
         cuda: ${{ matrix.cuda }}
         visual_studio: ${{ matrix.visual_studio }}
       shell: powershell
       run: .\scripts\actions\install_cuda_windows.ps1
+
+      # Note: redist doesnt' include dev headers of everything so this might not work...
+    - name: Install CUDA (redist)
+      if: ${{ matrix.redist == 'true' }}
+      env: 
+        cuda: ${{ matrix.cuda }}
+        visual_studio: ${{ matrix.visual_studio }}
+      shell: pwsh
+      run: |
+        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/windows-x86_64/cuda_nvcc-windows-x86_64-13.0.88-archive.zip"
+        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/visual_studio_integration/windows-x86_64/visual_studio_integration-windows-x86_64-13.0.85-archive.zip"
+        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/libcurand/windows-x86_64/libcurand-windows-x86_64-10.4.0.35-archive.zip"
+        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvrtc/windows-x86_64/cuda_nvrtc-windows-x86_64-13.0.88-archive.zip"
+        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_cudart/windows-x86_64/cuda_cudart-windows-x86_64-13.0.88-archive.zip"
+        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_cccl/windows-x86_64/cuda_cccl-windows-x86_64-13.0.85-archive.zip"
+        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/libnvjitlink/windows-x86_64/libnvjitlink-windows-x86_64-13.0.88-archive.zip"
+        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/cuda_crt/windows-x86_64/cuda_crt-windows-x86_64-13.0.88-archive.zip"
+        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/libnvptxcompiler/windows-x86_64/libnvptxcompiler-windows-x86_64-13.0.88-archive.zip"
+        curl -O "https://developer.download.nvidia.com/compute/cuda/redist/libnvvm/windows-x86_64/libnvvm-windows-x86_64-13.0.88-archive.zip"
+        # make the cuda toolkit dir
+        mkdir "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0"
+
+        # unzip all the zip files into the toolkit dir
+        7z.exe x "cuda_nvcc-windows-x86_64-13.0.88-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
+        7z.exe x "visual_studio_integration-windows-x86_64-13.0.85-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
+        7z.exe x "libcurand-windows-x86_64-10.4.0.35-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
+        7z.exe x "cuda_nvrtc-windows-x86_64-13.0.88-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
+        7z.exe x "cuda_cudart-windows-x86_64-13.0.88-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
+        7z.exe x "cuda_cccl-windows-x86_64-13.0.85-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
+        7z.exe x "libnvjitlink-windows-x86_64-13.0.88-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
+        7z.exe x "cuda_crt-windows-x86_64-13.0.88-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
+        7z.exe x "libnvptxcompiler-windows-x86_64-13.0.88-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
+        7z.exe x "libnvvm-windows-x86_64-13.0.88-archive.zip" -o"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\"
+
+        # delete the zip files
+        rm "cuda_nvcc-windows-x86_64-13.0.88-archive.zip"
+        rm "visual_studio_integration-windows-x86_64-13.0.85-archive.zip"
+        rm "libcurand-windows-x86_64-10.4.0.35-archive.zip"
+        rm "cuda_nvrtc-windows-x86_64-13.0.88-archive.zip"
+        rm "cuda_cudart-windows-x86_64-13.0.88-archive.zip"
+        rm "cuda_cccl-windows-x86_64-13.0.85-archive.zip"
+        rm "libnvjitlink-windows-x86_64-13.0.88-archive.zip"
+        rm "cuda_crt-windows-x86_64-13.0.88-archive.zip"
+        rm "libnvptxcompiler-windows-x86_64-13.0.88-archive.zip"
+        rm "libnvvm-windows-x86_64-13.0.88-archive.zip"
+
+        # Move files from each extracted zip directory into the actual location
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_nvcc-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\visual_studio_integration-windows-x86_64-13.0*. -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 85-archive\"
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libcurand-windows-x86_64-10.4.0.35-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_nvrtc-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_cudart-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_cccl-windows-x86_64-13.0.85-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libnvjitlink-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\cuda_crt-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libnvptxcompiler-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
+        cp -Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\libnvvm-windows-x86_64-13.0.88-archive\*" -Destination "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\" 
+
+        # Export env vars (pwsh required?)
+        "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\bin" >> $env:GITHUB_PATH
+        "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0" >> $env:GITHUB_ENV
+        "CUDA_PATH_V13_0=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0" >> $env:GITHUB_ENV
 
     - name: nvcc check
       shell: powershell

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -108,6 +108,7 @@ jobs:
 
         # Export env vars (pwsh required?)
         "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\bin" >> $env:GITHUB_PATH
+        "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0\nvvm" >> $env:GITHUB_PATH
         "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0" >> $env:GITHUB_ENV
         "CUDA_PATH_V13_0=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0" >> $env:GITHUB_ENV
 
@@ -118,6 +119,11 @@ jobs:
         ls $env:CUDA_PATH
         ls $env:CUDA_PATH\bin
         ls $env:CUDA_PATH\include
+
+    - name: manual nvcc
+      shell: bash
+      run: |
+        nvcc -o main src/main.cu -Iinclude -Imain -std=c++14
 
     - name: cmake version
       shell: bash

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -67,11 +67,11 @@ jobs:
             redist: "false"
             visual_studio: "Visual Studio 17 2022"
           - os: windows-2022
-            cuda: "11.6.1"
+            cuda: "12.0.0"
             redist: "true"
             visual_studio: "Visual Studio 17 2022"
           - os: windows-2022
-            cuda: "11.6.1"
+            cuda: "12.0.0"
             redist: "false"
             visual_studio: "Visual Studio 17 2022"
     env:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -120,6 +120,9 @@ jobs:
         ls $env:CUDA_PATH\bin
         ls $env:CUDA_PATH\include
 
+    - name: Enable Developer Command Prompt
+      uses: ilammy/msvc-dev-cmd@v1.13.0
+
     - name: manual nvcc
       shell: bash
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-build/
+build**/

--- a/scripts/actions/install_cuda_ubuntu.sh
+++ b/scripts/actions/install_cuda_ubuntu.sh
@@ -15,6 +15,7 @@ CUDA_PACKAGES_IN=(
     "cuda-nvrtc-dev"
     "libcurand-dev" # 11-0+
     "cuda-cccl" # 11.4+, provides cub and thrust. On 11.3 known as cuda-thrust-11-3
+    "libnvjitlink-dev" # 12.0+
 )
 
 ## -------------------
@@ -104,8 +105,11 @@ do :
             continue
         fi
     fi
+    # libnvjitlink not required prior to CUDA 12.0
+    if [[ ${package} == libnvjitlink-dev* ]] && version_lt "$CUDA_VERSION_MAJOR_MINOR" "12.0" ;then
+        continue
     # CUDA 11+ includes lib* / lib*-dev packages, which if they existed previously where cuda-cu*- / cuda-cu*-dev-
-    if [[ ${package} == libcu* ]] && version_lt "$CUDA_VERSION_MAJOR_MINOR" "11.0" ; then
+    elif [[ ${package} == lib* ]] && version_lt "$CUDA_VERSION_MAJOR_MINOR" "11.0" ; then
         package="${package/libcu/cuda-cu}"
     fi
     # Build the full package name and append to the string.
@@ -120,13 +124,14 @@ CPU_ARCH="x86_64"
 PIN_FILENAME="cuda-ubuntu${UBUNTU_VERSION}.pin"
 PIN_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/${CPU_ARCH}/${PIN_FILENAME}"
 # apt keyring package now available https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/
-KERYRING_PACKAGE_FILENAME="cuda-keyring_1.0-1_all.deb"
+KERYRING_PACKAGE_FILENAME="cuda-keyring_1.1-1_all.deb"
 KEYRING_PACKAGE_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/${CPU_ARCH}/${KERYRING_PACKAGE_FILENAME}"
 REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/${CPU_ARCH}/"
 
 echo "PIN_FILENAME ${PIN_FILENAME}"
 echo "PIN_URL ${PIN_URL}"
 echo "KEYRING_PACKAGE_URL ${KEYRING_PACKAGE_URL}"
+echo "APT_KEY_URL ${APT_KEY_URL}"
 
 ## -----------------
 ## Check for root/sudo
@@ -182,6 +187,7 @@ export LD_LIBRARY_PATH="$CUDA_PATH/lib:$LD_LIBRARY_PATH"
 export LD_LIBRARY_PATH="$CUDA_PATH/lib64:$LD_LIBRARY_PATH"
 # Check nvcc is now available.
 nvcc -V
+
 
 # If executed on github actions, make the appropriate echo statements to update the environment
 if [[ $GITHUB_ACTIONS ]]; then

--- a/scripts/actions/install_cuda_windows.ps1
+++ b/scripts/actions/install_cuda_windows.ps1
@@ -6,16 +6,6 @@
 # From 11.0, the download url/toolkit version is separate from the cudart version.
 # Releases since 11.5.1 (including 11.4.4) use `windows` rather than `win10` in the uri, due to windows 11 inclusion
 $CUDA_KNOWN_URLS = @{
-    "8.0.44"   = "https://developer.nvidia.com/compute/cuda/8.0/Prod/network_installers/cuda_8.0.44_win10_network-exe";
-    "8.0.61"   = "https://developer.nvidia.com/compute/cuda/8.0/Prod2/network_installers/cuda_8.0.61_win10_network-exe";
-    "9.0.176"  = "https://developer.nvidia.com/compute/cuda/9.0/Prod/network_installers/cuda_9.0.176_win10_network-exe";
-    "9.1.85"   = "https://developer.nvidia.com/compute/cuda/9.1/Prod/network_installers/cuda_9.1.85_win10_network";
-    "9.2.148"  = "https://developer.nvidia.com/compute/cuda/9.2/Prod2/network_installers2/cuda_9.2.148_win10_network";
-    "10.0.130" = "https://developer.nvidia.com/compute/cuda/10.0/Prod/network_installers/cuda_10.0.130_win10_network";
-    "10.1.105" = "https://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.105_win10_network.exe";
-    "10.1.168" = "https://developer.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.168_win10_network.exe";
-    "10.1.243" = "https://developer.download.nvidia.com/compute/cuda/10.1/Prod/network_installers/cuda_10.1.243_win10_network.exe";
-    "10.2.89"  = "https://developer.download.nvidia.com/compute/cuda/10.2/Prod/network_installers/cuda_10.2.89_win10_network.exe";
     "11.0.1" = "https://developer.download.nvidia.com/compute/cuda/11.0.1/network_installers/cuda_11.0.1_win10_network.exe";
     "11.0.2" = "https://developer.download.nvidia.com/compute/cuda/11.0.2/network_installers/cuda_11.0.2_win10_network.exe";
     "11.0.3" = "https://developer.download.nvidia.com/compute/cuda/11.0.3/network_installers/cuda_11.0.3_win10_network.exe";
@@ -40,15 +30,35 @@ $CUDA_KNOWN_URLS = @{
     "11.7.0" = "https://developer.download.nvidia.com/compute/cuda/11.7.0/network_installers/cuda_11.7.0_windows_network.exe";
     "11.7.1" = "https://developer.download.nvidia.com/compute/cuda/11.7.1/network_installers/cuda_11.7.1_windows_network.exe";
     "11.8.0" = "https://developer.download.nvidia.com/compute/cuda/11.8.0/network_installers/cuda_11.8.0_windows_network.exe";
-    "12.0.0" = "https://developer.download.nvidia.com/compute/cuda/12.0.0/network_installers/cuda_12.0.0_windows_network.exe"
+    "12.0.0" = "https://developer.download.nvidia.com/compute/cuda/12.0.0/network_installers/cuda_12.0.0_windows_network.exe";
+    "12.0.1" = "https://developer.download.nvidia.com/compute/cuda/12.0.1/network_installers/cuda_12.0.1_windows_network.exe";
+    "12.1.0" = "https://developer.download.nvidia.com/compute/cuda/12.1.0/network_installers/cuda_12.1.0_windows_network.exe";
+    "12.2.0" = "https://developer.download.nvidia.com/compute/cuda/12.2.0/network_installers/cuda_12.2.0_windows_network.exe";
+    "12.2.1" = "https://developer.download.nvidia.com/compute/cuda/12.2.1/network_installers/cuda_12.2.1_windows_network.exe";
+    "12.2.2" = "https://developer.download.nvidia.com/compute/cuda/12.2.2/network_installers/cuda_12.2.2_windows_network.exe";
+    "12.3.0" = "https://developer.download.nvidia.com/compute/cuda/12.3.0/network_installers/cuda_12.3.0_windows_network.exe";
+    "12.3.1" = "https://developer.download.nvidia.com/compute/cuda/12.3.1/network_installers/cuda_12.3.1_windows_network.exe";
+    "12.3.2" = "https://developer.download.nvidia.com/compute/cuda/12.3.2/network_installers/cuda_12.3.2_windows_network.exe";
+    "12.4.0" = "https://developer.download.nvidia.com/compute/cuda/12.4.0/network_installers/cuda_12.4.0_windows_network.exe";
+    "12.4.1" = "https://developer.download.nvidia.com/compute/cuda/12.4.1/network_installers/cuda_12.4.1_windows_network.exe";
+    "12.5.0" = "https://developer.download.nvidia.com/compute/cuda/12.5.0/network_installers/cuda_12.5.0_windows_network.exe";
+    "12.5.1" = "https://developer.download.nvidia.com/compute/cuda/12.5.1/network_installers/cuda_12.5.1_windows_network.exe";
+    "12.6.0" = "https://developer.download.nvidia.com/compute/cuda/12.6.0/network_installers/cuda_12.6.0_windows_network.exe";
+    "12.6.1" = "https://developer.download.nvidia.com/compute/cuda/12.6.1/network_installers/cuda_12.6.1_windows_network.exe";
+    "12.6.2" = "https://developer.download.nvidia.com/compute/cuda/12.6.2/network_installers/cuda_12.6.2_windows_network.exe";
+    "12.6.3" = "https://developer.download.nvidia.com/compute/cuda/12.6.3/network_installers/cuda_12.6.3_windows_network.exe";
+    "12.8.0" = "https://developer.download.nvidia.com/compute/cuda/12.8.0/network_installers/cuda_12.8.0_windows_network.exe";
+    "12.8.1" = "https://developer.download.nvidia.com/compute/cuda/12.8.1/network_installers/cuda_12.8.1_windows_network.exe";
+    "12.9.0" = "https://developer.download.nvidia.com/compute/cuda/12.9.0/network_installers/cuda_12.9.0_windows_network.exe";
+    "12.9.1" = "https://developer.download.nvidia.com/compute/cuda/12.9.1/network_installers/cuda_12.9.1_windows_network.exe";
+    "13.0.0" = "https://developer.download.nvidia.com/compute/cuda/13.0.0/network_installers/cuda_13.0.0_windows_network.exe";
+    "13.0.1" = "https://developer.download.nvidia.com/compute/cuda/13.0.1/network_installers/cuda_13.0.1_windows_network.exe";
 }
 
 # @todo - change this to be based on _MSC_VER intead, or invert it to be CUDA keyed instead
 $VISUAL_STUDIO_MIN_CUDA = @{
     "2022" = "11.6.0";
     "2019" = "10.1";
-    "2017" = "10.0"; # Depends on which version of 2017! 9.0 to 10.0 depending on version
-    "2015" = "8.0";  # Might support older, unsure. Depracated as of 11.1, unsupported in 11.2
 }
 
 # cuda_runtime.h is in nvcc <= 10.2, but cudart >= 11.0
@@ -60,6 +70,12 @@ $CUDA_PACKAGES_IN = @(
     "nvrtc_dev";
     "cudart";
     "thrust";
+    "thrust";
+    "nvjitlink";
+    # cuda 13+ packages
+    "crt";
+    "nvptxcompiler";
+    "nvvm";
 )
 
 ## -------------------
@@ -112,6 +128,18 @@ Foreach ($package in $CUDA_PACKAGES_IN) {
     } elseif($package -eq "thrust" -and [version]$CUDA_VERSION_FULL -lt [version]"11.3") {
         # Thrust is a package from CUDA 11.3, otherwise it should be skipped.
         continue
+    } elseif($package -eq "nvjitlink" -and [version]$CUDA_VERSION_FULL -lt [version]"12.0") {
+        # nvjitlink is a from CUDA 12.0, otherwise it should be skipped.
+        continue
+    } elseif($package -eq "crt" -and [version]$CUDA_VERSION_FULL -lt [version]"13.0") {
+        # crt is a from CUDA 13.0, otherwise it should be skipped.
+        continue
+    } elseif($package -eq "nvptxcompiler" -and [version]$CUDA_VERSION_FULL -lt [version]"13.0") {
+        # nvptxcompiler is a from CUDA 13.0, otherwise it should be skipped.
+        continue
+    } elseif($package -eq "nvvm" -and [version]$CUDA_VERSION_FULL -lt [version]"13.0") {
+        # nvvm is a from CUDA 13.0, otherwise it should be skipped.
+        continue
     }
     $CUDA_PACKAGES += " $($package)_$($CUDA_MAJOR).$($CUDA_MINOR)"
 }
@@ -160,7 +188,7 @@ while (-not $downloaded) {
         Write-Output "Downloading Complete"
         $downloaded=$true
     } else {
-        # If downlaod failed, either wait and try again, or give up and error.
+        # If download failed, either wait and try again, or give up and error.
         if ($download_attempt -le $download_attempts_max) {
             Write-Output "Error: Failed to download $($CUDA_REPO_PKG_LOCAL) (attempt $($download_attempt)/$($download_attempts_max)). Retrying."
             # Sleep for a number of seconds.

--- a/scripts/actions/install_cuda_windows_redist.ps1
+++ b/scripts/actions/install_cuda_windows_redist.ps1
@@ -1,0 +1,164 @@
+# Assumes vswhere.exe, curl and 7z.exe are on the path
+
+## -------------------
+## Constants
+## -------------------
+
+# The root server with redist packages and manifests
+$REDIST_ROOT = "https://developer.download.nvidia.com/compute/cuda/redist"
+$PLATFORM = "windows-x86_64"
+
+# So far, the mainifests all follow the same pattern, so no need for a list of known cuda versions (yet)
+
+# Cuda pacakges to install, separate name conversions may be required
+$CUDA_PACKAGES_IN = @(
+    "visual_studio_integration";
+    "cuda_nvcc";
+    "cuda_nvrtc";
+    "cuda_cudart";
+    "cuda_cccl";
+    "libcurand";
+    # cuda 12+
+    "libnvjitlink";
+    # cuda 13+ packages
+    "cuda_crt";
+    "libnvptxcompiler";
+    "libnvvm";
+)
+
+# Get the cuda version from the environment as env:cuda.
+$CUDA_VERSION_FULL = $env:cuda
+# Make sure CUDA_VERSION_FULL is set and valid, otherwise error.
+
+# Validate CUDA version, extracting components via regex
+$cuda_ver_matched = $CUDA_VERSION_FULL -match "^(?<major>[1-9][0-9]*)\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)$"
+if(-not $cuda_ver_matched){
+    Write-Output "Invalid CUDA version specified, <major>.<minor>.<patch> required. '$CUDA_VERSION_FULL'."
+    exit 1
+}
+$CUDA_MAJOR=$Matches.major
+$CUDA_MINOR=$Matches.minor
+$CUDA_PATCH=$Matches.patch
+
+# If cuda version is le the first redist with a full manifest (11.4.2), error
+# 11.4.2 is the first version with a releasee date and cuda pacakges
+if([version]$CUDA_VERSION_FULL -lt [version]"11.4.2") {
+    Write-Output "Error: cuda version $($CUDA_VERSION_FULL) is below the minimum 11.4.2 available via $($REDIST_ROOT). Aborting."
+    # Abort the script.
+    exit 1
+}
+
+# adjust packages based on which cuda versions they are available in
+$CUDA_PACKAGES = @()
+Foreach ($package in $CUDA_PACKAGES_IN) {
+   if($package -eq "libnvjitlink" -and [version]$CUDA_VERSION_FULL -lt [version]"12.0") {
+        # nvjitlink is a from CUDA 12.0, otherwise it should be skipped.
+        continue
+    } elseif($package -eq "cuda_crt" -and [version]$CUDA_VERSION_FULL -lt [version]"13.0") {
+        # crt is a from CUDA 13.0, otherwise it should be skipped.
+        continue
+    } elseif($package -eq "libnvptxcompiler" -and [version]$CUDA_VERSION_FULL -lt [version]"13.0") {
+        # nvptxcompiler is a from CUDA 13.0, otherwise it should be skipped.
+        continue
+    } elseif($package -eq "libnvvm" -and [version]$CUDA_VERSION_FULL -lt [version]"13.0") {
+        # nvvm is a from CUDA 13.0, otherwise it should be skipped.
+        continue
+    }
+    $CUDA_PACKAGES += "$($package)"
+}
+echo "$($CUDA_PACKAGES)"
+
+
+# Comptue the manifest uri/url
+$CUDA_REDIST_MANIFEST_URL="$REDIST_ROOT/redistrib_$($CUDA_VERSION_FULL).json"
+
+# Build the cuda toolkit directory
+$CUDA_TOOLKIT_DIR = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$($CUDA_MAJOR).$($CUDA_MINOR)"
+
+# Find where visual studio is and where the build customiszation files should go.
+$vswherePath = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+$vs_path = & $vswherePath -latest -property installationPath
+$vs_version = & $vswherePath -latest -property installationVersion
+# Gross and semi-hardcoded to be 160/170
+$vs_version_path = "v$(-join ($vs_version.Split('.'))[0])0"
+$build_customizations_path = Join-Path -Path $vs_path -ChildPath "MSBuild\Microsoft\VC\$vs_version_path\BuildCustomizations"
+
+# Suppress Invoke-WebRequest progress bars for faster download
+$ProgressPreference = 'SilentlyContinue'
+
+# Download the manifest for the requrested cuda version
+echo "manifest: ${CUDA_REDIST_MANIFEST_URL}"
+$manifest = Invoke-RestMethod -Uri $CUDA_REDIST_MANIFEST_URL
+# echo "$($manifest.release_label)"
+
+# @todo: use a temorary directory
+# 
+# For each package, if it is found: download, unzip, copy/install and clean up
+$json_packages = ""
+Foreach ($package in $CUDA_PACKAGES) {
+    # Ensure the package is in the manifest, else emit a warning and skip the package
+    if($manifest.$package -eq $null) {
+        echo "Warning: package $package not found in manifest"
+        continue
+    }
+    # Ensure the platform is available for the package, else emit a warning and skip the package
+    if ($manifest.$package.$PLATFORM -eq $null) {
+        echo "Warning: platform $PLATFORM not found for pacakge $package in manifest"
+        continue
+    }
+    # Ensure the a relative url is is available, else emit a warning and skip the package
+    if ($manifest.$package.$PLATFORM.relative_path -eq $null) {
+        echo "Warning: $package.$PLATFORM.relative_path is missing, unable to download"
+        continue
+    }
+    # Download the package. 
+    $package_url = "$($REDIST_ROOT)/$($manifest.$package.$PLATFORM.relative_path)"
+    $package_zip = Split-Path -Path $package_url -Leaf
+    $package_dir = [System.IO.Path]::GetFileNameWithoutExtension($package_zip)
+
+    echo "Downloading $package from $package_url"
+    Invoke-WebRequest -Uri $package_url -OutFile $package_zip
+    echo "Extracting $package_zip"
+    Expand-Archive -Path $package_zip -DestinationPath . -Force
+    # 'install' the package (I.e. copy to the expected location). some packages need special handling
+    if ($package -eq "visual_studio_integration") {
+        # Install build customisations, assuming consistnet packaging from nvidia
+        echo "Installing build customisations to $build_customizations_path"
+        New-Item -Path "$build_customizations_path" -ItemType Directory -Force
+        $source = "$($package_dir)\visual_studio_integration\MSBuildExtensions"
+        echo "$source"
+        cp -Path "$source\*" -Destination "$build_customizations_path" -Recurse
+    } else {
+        echo "Installing $package in $CUDA_TOOLKIT_DIR"
+        New-Item -Path "$CUDA_TOOLKIT_DIR" -ItemType Directory -Force
+        # Just extract into the expected cuda installation directory
+        cp -Path "$package_dir\*" -Destination "$CUDA_TOOLKIT_DIR\" -Recurse -Force
+    }
+    # Delete the extracted files
+    Remove-Item -Path $package_dir -Recurse -Force
+    # Delete the downloaded zip
+    Remove-Item -Path $package_zip -Recurse -Force
+}
+
+# Set environment variables
+
+# Store the CUDA_PATH in the environment for the current session, to be forwarded in the action.
+$CUDA_PATH = "$CUDA_TOOLKIT_DIR"
+$CUDA_PATH_VX_Y = "CUDA_PATH_V$($CUDA_MAJOR)_$($CUDA_MINOR)"
+# Set environmental variables in this session
+$env:CUDA_PATH = "$($CUDA_PATH)"
+$env:CUDA_PATH_VX_Y = "$($CUDA_PATH_VX_Y)"
+Write-Output "CUDA_PATH $($CUDA_PATH)"
+Write-Output "CUDA_PATH_VX_Y $($CUDA_PATH_VX_Y)"
+
+# PATH needs updating elsewhere, anything in here won't persist.
+# Append $CUDA_PATH/bin to path.
+
+# If executing on github actions, emit the appropriate echo statements to update environment variables
+if (Test-Path "env:GITHUB_ACTIONS") {
+    # Set paths for subsequent steps, using $env:CUDA_PATH
+    echo "Adding CUDA to CUDA_PATH, CUDA_PATH_X_Y and PATH"
+    echo "CUDA_PATH=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    echo "$env:CUDA_PATH_VX_Y=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    echo "$env:CUDA_PATH/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+}


### PR DESCRIPTION
Test / investigate / implement installing CUDA on windows on CI via the `redist` packages rather than the network installer.

This may or may not be faster / more reliable than the network installer which has been hanging a lot for recent CUDA versions as of late. 